### PR TITLE
Dev/1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Ewon Flexy Extensions Library Changelog
 
+## Version 1.3.1
+### Features
+- N/A
+### Bug Fixes
+- Fix bug preventing access of HTTP timeout setting function.
+### Other
+- N/A
+
 ## Version 1.3.0
 ### Features
 - Added system.http package

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ As required, you can include additional libraries or dependencies using the Mave
    <dependency>
       <groupId>com.hms_networks.americas.sc</groupId>
       <artifactId>extensions</artifactId>
-      <version>1.3.0</version>
+      <version>1.3.1</version>
    </dependency>
    ...
 </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <!-- PROJECT NAME -->
   <name>Ewon Flexy Extensions Library</name>
   <!-- PROJECT VERSION -->
-  <version>1.3.0</version>
+  <version>1.3.1</version>
   <!-- PROJECT GROUP ID (PARENT PACKAGE) -->
   <groupId>com.hms_networks.americas.sc</groupId>
   <!-- PROJECT ARTIFACT ID (ROOT PACKAGE NAME) -->

--- a/src/main/java/com/hms_networks/americas/sc/extensions/package.html
+++ b/src/main/java/com/hms_networks/americas/sc/extensions/package.html
@@ -5,7 +5,7 @@ environment by the HMS Networks, MU Americas Solution Center. These
 extension classes include many supplemental features, and the addition
 of new functionality which may not be present in the supported Java version.
 
-@version 1.3.0
+@version 1.3.1
 @author HMS Networks, MU Americas Solution Center
 </BODY>
 </HTML>

--- a/src/main/java/com/hms_networks/americas/sc/extensions/system/http/SCHttpUtility.java
+++ b/src/main/java/com/hms_networks/americas/sc/extensions/system/http/SCHttpUtility.java
@@ -49,7 +49,7 @@ public class SCHttpUtility {
    * @param seconds the timeout in seconds
    * @throws Exception if unable to set timeouts
    */
-  private static void setHttpTimeouts(String seconds) throws Exception {
+  public static void setHttpTimeouts(String seconds) throws Exception {
     final String httpSendTimeoutName = "HTTPC_SDTO";
     final String httpReadTimeoutName = "HTTPC_RDTO";
 


### PR DESCRIPTION
My apologies, but version 1.3.0 is going to be very short-lived...

The HTTP timeouts function is in multiple of our connectors, and I tested then copied/pasted from the same main class that it was being called from, so private vs public scope did not matter/cause an issue. Did not realize the issue until went to use it from another (not the same) class.