### PR TITLE
Remove java.nio methods in Base64.java

### DIFF
--- a/src/main/java/com/hms_networks/americas/sc/extensions/util/Base64.java
+++ b/src/main/java/com/hms_networks/americas/sc/extensions/util/Base64.java
@@ -1151,50 +1151,6 @@ public class Base64 {
   } // end encode3to4
 
   /**
-   * Performs Base64 encoding on the <code>raw</code> ByteBuffer, writing it to the <code>encoded
-   * </code> ByteBuffer. This is an experimental feature. Currently it does not pass along any
-   * options (such as {@link #DO_BREAK_LINES} or {@link #GZIP}.
-   *
-   * @param raw input buffer
-   * @param encoded output buffer
-   * @since 2.3
-   */
-  public static void encode(java.nio.ByteBuffer raw, java.nio.ByteBuffer encoded) {
-    byte[] raw3 = new byte[3];
-    byte[] enc4 = new byte[4];
-
-    while (raw.hasRemaining()) {
-      int rem = Math.min(3, raw.remaining());
-      raw.get(raw3, 0, rem);
-      Base64.encode3to4(enc4, raw3, rem, Base64.NO_OPTIONS);
-      encoded.put(enc4);
-    } // end input remaining
-  }
-
-  /**
-   * Performs Base64 encoding on the <code>raw</code> ByteBuffer, writing it to the <code>encoded
-   * </code> CharBuffer. This is an experimental feature. Currently it does not pass along any
-   * options (such as {@link #DO_BREAK_LINES} or {@link #GZIP}.
-   *
-   * @param raw input buffer
-   * @param encoded output buffer
-   * @since 2.3
-   */
-  public static void encode(java.nio.ByteBuffer raw, java.nio.CharBuffer encoded) {
-    byte[] raw3 = new byte[3];
-    byte[] enc4 = new byte[4];
-
-    while (raw.hasRemaining()) {
-      int rem = Math.min(3, raw.remaining());
-      raw.get(raw3, 0, rem);
-      Base64.encode3to4(enc4, raw3, rem, Base64.NO_OPTIONS);
-      for (int i = 0; i < 4; i++) {
-        encoded.put((char) (enc4[i] & 0xFF));
-      }
-    } // end input remaining
-  }
-
-  /**
    * Serializes an object and returns the Base64-encoded version of that serialized object.
    *
    * <p>As of v 2.3, if the object cannot be serialized or there is another error, the method will


### PR DESCRIPTION
Remove methods using classes from the java.nio
package from the Base64.java utility class.

The java.nio package is exclusive to Java 7 and
later versions, thus causing potential issues with references to or checks against the now-removed
methods within Java 1.4.

fixes #32 closes #32.