### PR TITLE
Iatr/circular

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Ewon Flexy Extensions Library Changelog
 
+## Version 1.13.11
+### Features
+- N/A
+### Bug Fixes
+- Corrected check for circularized file error, to only check for error since the last EBD request. 
+
 ## Version 1.13.10
 ### Features
 - N/A

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ As required, you can include additional libraries or dependencies using the Mave
    <dependency>
       <groupId>com.hms_networks.americas.sc</groupId>
       <artifactId>extensions</artifactId>
-      <version>1.13.10</version>
+      <version>1.13.11</version>
    </dependency>
    ...
 </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <!-- PROJECT NAME -->
   <name>Ewon Flexy Extensions Library</name>
   <!-- PROJECT VERSION -->
-  <version>1.13.10</version>
+  <version>1.13.11</version>
   <!-- PROJECT GROUP ID (PARENT PACKAGE) -->
   <groupId>com.hms_networks.americas.sc</groupId>
   <!-- PROJECT ARTIFACT ID (ROOT PACKAGE NAME) -->

--- a/src/main/java/com/hms_networks/americas/sc/extensions/alarms/AlarmMonitor.java
+++ b/src/main/java/com/hms_networks/americas/sc/extensions/alarms/AlarmMonitor.java
@@ -4,7 +4,6 @@ import com.ewon.ewonitf.EvtTagAlarmListener;
 import com.hms_networks.americas.sc.extensions.system.time.SCTimeUtils;
 import com.hms_networks.americas.sc.extensions.taginfo.TagInfoManager;
 import com.hms_networks.americas.sc.extensions.taginfo.TagType;
-
 import java.util.Date;
 
 /**

--- a/src/main/java/com/hms_networks/americas/sc/extensions/eventfile/EventFile.java
+++ b/src/main/java/com/hms_networks/americas/sc/extensions/eventfile/EventFile.java
@@ -16,6 +16,12 @@ import java.util.List;
  * @since 1.6.0
  */
 public class EventFile {
+  /** Event File line delimiter */
+  private static final String EVENT_FILE_LINE_DELIMITER = "\n";
+
+  /** Event File line token delimiter */
+  private static final String EVENT_FILE_LINE_TOKEN_DELIMITER = ";";
+
   /**
    * Read EventFile, check for File Circularized event
    *
@@ -84,7 +90,7 @@ public class EventFile {
   private static boolean parseEventFileExportResponse(Exporter exporter, String eventId)
       throws IOException, JSONException {
     final String exporterFile = StringUtils.getStringFromInputStream(exporter, "UTF-8");
-    final List eventFileLines = StringUtils.split(exporterFile, "\n");
+    final List eventFileLines = StringUtils.split(exporterFile, EVENT_FILE_LINE_DELIMITER);
 
     exporter.close();
     for (int x = 1; x < eventFileLines.size(); x++) {
@@ -106,7 +112,8 @@ public class EventFile {
   private static boolean checkEventFileLine(String line, String target) {
     // Create tokenizer to process line
     final boolean returnDelimiters = false;
-    QuoteSafeStringTokenizer tokenizer = new QuoteSafeStringTokenizer(line, ";", returnDelimiters);
+    QuoteSafeStringTokenizer tokenizer =
+        new QuoteSafeStringTokenizer(line, EVENT_FILE_LINE_TOKEN_DELIMITER, returnDelimiters);
 
     // Loop through each token
     String currentToken = "";

--- a/src/main/java/com/hms_networks/americas/sc/extensions/eventfile/EventFile.java
+++ b/src/main/java/com/hms_networks/americas/sc/extensions/eventfile/EventFile.java
@@ -1,6 +1,7 @@
 package com.hms_networks.americas.sc.extensions.eventfile;
 
 import com.ewon.ewonitf.Exporter;
+import com.hms_networks.americas.sc.extensions.historicaldata.CircularizedFileCheck;
 import com.hms_networks.americas.sc.extensions.historicaldata.EbdTimeoutException;
 import com.hms_networks.americas.sc.extensions.historicaldata.HistoricalDataManager;
 import com.hms_networks.americas.sc.extensions.json.JSONException;
@@ -42,6 +43,7 @@ public class EventFile {
   /**
    * Read EventFile, check for File Circularized event
    *
+   * @deprecated use {@link CircularizedFileCheck}
    * @return boolean - did a File Circularized event occur in the recent past
    * @throws EbdTimeoutException for timeout in EBD read
    * @throws IOException for errors in parsing response

--- a/src/main/java/com/hms_networks/americas/sc/extensions/historicaldata/CircularizedFileCheck.java
+++ b/src/main/java/com/hms_networks/americas/sc/extensions/historicaldata/CircularizedFileCheck.java
@@ -1,0 +1,30 @@
+package com.hms_networks.americas.sc.extensions.historicaldata;
+
+import com.hms_networks.americas.sc.extensions.eventfile.EventFile;
+import java.io.IOException;
+
+/**
+ * Class to check for Circularized file exceptions
+ *
+ * @author HMS Networks, MU Americas Solution Center
+ * @since 1.13.11
+ */
+public class CircularizedFileCheck {
+  /** Event Id for circularized file error */
+  private static final String CIRCULARIZED_FILE_ID_STRING = "23607";
+
+  /**
+   * Read EventFile, check for File Circularized event after start timestamp
+   *
+   * @param absoluteSinceStartTimeMilliseconds - absolute epoch start timestamp for start time of
+   *     Event File request
+   * @return boolean - did a File Circularized event occur in the recent past
+   * @throws EbdTimeoutException - for EBD timeout
+   * @throws IOException - for Exception reading input stream
+   */
+  public static boolean didFileCircularizedEventOccurSinceAbsolute(
+      long absoluteSinceStartTimeMilliseconds) throws IOException, EbdTimeoutException {
+    return EventFile.didEventOccurSinceAbsolute(
+        CIRCULARIZED_FILE_ID_STRING, absoluteSinceStartTimeMilliseconds);
+  }
+}

--- a/src/main/java/com/hms_networks/americas/sc/extensions/historicaldata/HistoricalDataManager.java
+++ b/src/main/java/com/hms_networks/americas/sc/extensions/historicaldata/HistoricalDataManager.java
@@ -9,7 +9,6 @@ import com.hms_networks.americas.sc.extensions.datapoint.DataPointInteger;
 import com.hms_networks.americas.sc.extensions.datapoint.DataPointIntegerMappedString;
 import com.hms_networks.americas.sc.extensions.datapoint.DataPointString;
 import com.hms_networks.americas.sc.extensions.datapoint.DataQuality;
-import com.hms_networks.americas.sc.extensions.eventfile.EventFile;
 import com.hms_networks.americas.sc.extensions.fileutils.FileConstants;
 import com.hms_networks.americas.sc.extensions.json.JSONException;
 import com.hms_networks.americas.sc.extensions.string.QuoteSafeStringTokenizer;
@@ -136,11 +135,9 @@ public class HistoricalDataManager {
    * @return dataPoints
    * @throws IOException for parsing Exceptions
    * @throws JSONException for JSON parsing Exceptions
-   * @throws EbdTimeoutException timeout for reading event file
-   * @throws CircularizedFileException when event log indicates circularized event
    */
   private static ArrayList parseEBDHistoricalLogExportResponse(Exporter exporter)
-      throws IOException, JSONException, EbdTimeoutException, CircularizedFileException {
+      throws IOException, JSONException {
 
     final String exporterFile = StringUtils.getStringFromInputStream(exporter, "UTF-8");
     final List eventFileLines = StringUtils.split(exporterFile, "\n");
@@ -155,10 +152,6 @@ public class HistoricalDataManager {
 
     exporter.close();
 
-    // Check for Circularized Event
-    if (EventFile.didFileCircularizedEventOccur()) {
-      throw new CircularizedFileException("A circularized event was found in the event logs.");
-    }
     return dataPoints;
   }
 
@@ -316,8 +309,7 @@ public class HistoricalDataManager {
    * @throws IOException if unable to access or read file
    * @throws JSONException if unable to parse int to string enumeration file
    */
-  public static ArrayList parseHistoricalFile(String filename)
-      throws IOException, JSONException, EbdTimeoutException, CircularizedFileException {
+  public static ArrayList parseHistoricalFile(String filename) throws IOException, JSONException {
     final int sleepBetweenLinesMs = 5;
     final BufferedReader reader = new BufferedReader(new FileReader(filename));
 
@@ -357,11 +349,6 @@ public class HistoricalDataManager {
 
       // Read next line before looping again
       line = reader.readLine();
-    }
-
-    // Check for Circularized Event
-    if (EventFile.didFileCircularizedEventOccur()) {
-      throw new CircularizedFileException("A circularized event was found in the event logs.");
     }
 
     reader.close();

--- a/src/main/java/com/hms_networks/americas/sc/extensions/historicaldata/HistoricalDataQueueManager.java
+++ b/src/main/java/com/hms_networks/americas/sc/extensions/historicaldata/HistoricalDataQueueManager.java
@@ -376,6 +376,8 @@ public class HistoricalDataQueueManager {
     // Run standard EBD export call (int, float, ...)
     boolean stringHistorical = false;
 
+    final long startOfEbdHistoricalReadMs = System.currentTimeMillis();
+
     ArrayList queueData =
         HistoricalDataManager.readHistoricalFifo(
             ebdStartTime,
@@ -407,6 +409,12 @@ public class HistoricalDataQueueManager {
       // Parse string EBD export call and combine with standard EBD call results
       ArrayList queueStringData = HistoricalDataManager.parseHistoricalFile(ebdStringFileName);
       queueData.addAll(queueStringData);
+    }
+
+    // Check for Circularized Event
+    if (CircularizedFileCheck.didFileCircularizedEventOccurSinceAbsolute(
+        startOfEbdHistoricalReadMs)) {
+      throw new CircularizedFileException("A circularized event was found in the event logs.");
     }
 
     // Store end time +1 ms (to prevent duplicate data)

--- a/src/main/java/com/hms_networks/americas/sc/extensions/localdatafiles/LocalDataFileManager.java
+++ b/src/main/java/com/hms_networks/americas/sc/extensions/localdatafiles/LocalDataFileManager.java
@@ -6,11 +6,10 @@ import com.hms_networks.americas.sc.extensions.datapoint.DataType;
 import com.hms_networks.americas.sc.extensions.fileutils.FileAccessManager;
 import com.hms_networks.americas.sc.extensions.fileutils.FileManager;
 import com.hms_networks.americas.sc.extensions.logging.Logger;
+import com.hms_networks.americas.sc.extensions.system.time.LocalTimeOffsetCalculator;
 import com.hms_networks.americas.sc.extensions.system.time.SCTimeUtils;
 import com.hms_networks.americas.sc.extensions.taginfo.TagInfoManager;
 import com.hms_networks.americas.sc.extensions.taginfo.TagType;
-import com.hms_networks.americas.sc.extensions.system.time.LocalTimeOffsetCalculator;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.*;

--- a/src/main/java/com/hms_networks/americas/sc/extensions/package.html
+++ b/src/main/java/com/hms_networks/americas/sc/extensions/package.html
@@ -5,7 +5,7 @@ environment by the HMS Networks, MU Americas Solution Center. These
 extension classes include many supplemental features, and the addition
 of new functionality which may not be present in the supported Java version.
 
-@version 1.13.10
+@version 1.13.11
 @author HMS Networks, MU Americas Solution Center
 </BODY>
 </HTML>

--- a/src/main/java/com/hms_networks/americas/sc/extensions/realtimedata/RealTimeDataQueueManager.java
+++ b/src/main/java/com/hms_networks/americas/sc/extensions/realtimedata/RealTimeDataQueueManager.java
@@ -1,12 +1,11 @@
 package com.hms_networks.americas.sc.extensions.realtimedata;
 
-import java.util.ArrayList;
-
 import com.hms_networks.americas.sc.extensions.datapoint.DataPoint;
 import com.hms_networks.americas.sc.extensions.logging.Logger;
 import com.hms_networks.americas.sc.extensions.taginfo.TagGroup;
 import com.hms_networks.americas.sc.extensions.taginfo.TagInfo;
 import com.hms_networks.americas.sc.extensions.taginfo.TagInfoManager;
+import java.util.ArrayList;
 
 /**
  * This class is used to retrieve real time data from the Flexy.

--- a/src/main/java/com/hms_networks/americas/sc/extensions/realtimedata/RealTimeTagDataPointManager.java
+++ b/src/main/java/com/hms_networks/americas/sc/extensions/realtimedata/RealTimeTagDataPointManager.java
@@ -1,7 +1,5 @@
 package com.hms_networks.americas.sc.extensions.realtimedata;
 
-import java.util.ArrayList;
-
 import com.ewon.ewonitf.TagControl;
 import com.hms_networks.americas.sc.extensions.datapoint.DataPoint;
 import com.hms_networks.americas.sc.extensions.datapoint.DataPointBoolean;
@@ -11,6 +9,7 @@ import com.hms_networks.americas.sc.extensions.datapoint.DataPointString;
 import com.hms_networks.americas.sc.extensions.logging.Logger;
 import com.hms_networks.americas.sc.extensions.taginfo.TagInfo;
 import com.hms_networks.americas.sc.extensions.taginfo.TagType;
+import java.util.ArrayList;
 
 /**
  * This class will hold a list of data points for each tag. One instance of the class is made per


### PR DESCRIPTION
This update resolves a bug where the check for Circularized file looks back 1 minute in the Event File. This was changed to use absolute time and only look back to the most recent request. This error cased multiple error flags and requests. 

Closes #48 

![image](https://github.com/hms-networks/sc-ewon-flexy-extensions-lib/assets/72526279/d7c49fb4-bc64-4732-9294-586d51bccce9)
![image](https://github.com/hms-networks/sc-ewon-flexy-extensions-lib/assets/72526279/ebfc6512-f029-4b7d-8bce-3e48b120914a)
