### PR TITLE
Thk watchdog dev

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <!-- PROJECT NAME -->
   <name>Ewon Flexy Extensions Library</name>
   <!-- PROJECT VERSION -->
-  <version>1.15.2</version>
+  <version>1.15.3</version>
   <!-- PROJECT GROUP ID (PARENT PACKAGE) -->
   <groupId>com.hms_networks.americas.sc</groupId>
   <!-- PROJECT ARTIFACT ID (ROOT PACKAGE NAME) -->

--- a/src/main/java/com/hms_networks/americas/sc/extensions/package.html
+++ b/src/main/java/com/hms_networks/americas/sc/extensions/package.html
@@ -5,7 +5,7 @@ environment by the HMS Networks, MU Americas Solution Center. These
 extension classes include many supplemental features, and the addition
 of new functionality which may not be present in the supported Java version.
 
-@version 1.15.2
+@version 1.15.3
 @author HMS Networks, MU Americas Solution Center
 </BODY>
 </HTML>

--- a/starting-files/jvmrun
+++ b/starting-files/jvmrun
@@ -1,1 +1,1 @@
--heapsize 25M -classpath /usr/extensions-1.15.2-full.jar -emain com.hms_networks.americas.sc.extensions.ExtensionsMain
+-heapsize 25M -classpath /usr/extensions-1.15.3-full.jar -emain com.hms_networks.americas.sc.extensions.ExtensionsMain

--- a/web-docs/docs/02-CHANGELOG.mdx
+++ b/web-docs/docs/02-CHANGELOG.mdx
@@ -5,6 +5,10 @@ sidebar_label: Change Log
 toc_max_heading_level: 2
 ---
 
+## Version 1.15.3
+### Features
+- Added service timer to the application reboot watchdog to ensure application is in a stable state before allowing the watchdog to be serviced.
+
 ## Version 1.15.2
 ### Features
 - Added all supported Ewon HTTP methods to SCHttpUtility.java.

--- a/web-docs/docs/_partial/_pom_library.mdx
+++ b/web-docs/docs/_partial/_pom_library.mdx
@@ -7,7 +7,7 @@ import ScDocusaurusConfig from "@site/ScDocusaurusConfig.js";
   <dependency>
     <groupId>com.hms_networks.americas.sc</groupId>
     <artifactId>extensions</artifactId>
-    <version>1.15.2</version>
+    <version>1.15.3</version>
   </dependency>
   ...
 </dependencies>


### PR DESCRIPTION
The reboot watchdog functionality currently can be incorrectly used by the application if it implements servicing too quickly. This addition adds the functionality to enable a timer. The timer ensures that a specified amount of time passes before the watchdog is serviced. Ideally this would be in the 5-10 minute range (long enough to establish a VPN connection with the device). 

This prevents situations where the device is cyclically rebooting once every two minutes and the reboot watchdog is not triggered but a VPN connection is not possible., 