### PR TITLE
Add data poll blocking to framework

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <!-- PROJECT NAME -->
   <name>Ewon Flexy Extensions Library</name>
   <!-- PROJECT VERSION -->
-  <version>1.15.11</version>
+  <version>1.15.12</version>
   <!-- PROJECT GROUP ID (PARENT PACKAGE) -->
   <groupId>com.hms_networks.americas.sc</groupId>
   <!-- PROJECT ARTIFACT ID (ROOT PACKAGE NAME) -->

--- a/src/main/java/com/hms_networks/americas/sc/extensions/connectors/framework/AbstractConnectorMain.java
+++ b/src/main/java/com/hms_networks/americas/sc/extensions/connectors/framework/AbstractConnectorMain.java
@@ -107,6 +107,19 @@ public abstract class AbstractConnectorMain {
   private boolean isDataPollingDisabled = false;
 
   /**
+   * The boolean flag indicating whether the connector should data polling is blocked. This flag is
+   * used to determine whether the connector should block polling for data during each iteration of
+   * the main loop.
+   *
+   * <p>Unlike {@link #isDataPollingDisabled}, which indicates whether data polling has been
+   * disabled, this flag indicates whether data polling has been blocked due to a temporary
+   * condition or error.
+   *
+   * @since 1.15.12
+   */
+  private boolean isDataPollingBlocked = false;
+
+  /**
    * The boolean flag indicating whether the connector automatic restart is enabled. This flag is
    * used to determine whether the connector automatic restart functionality was enabled during
    * initialization/start up.
@@ -246,6 +259,22 @@ public abstract class AbstractConnectorMain {
    */
   public void setConnectorCycleTime(SCTimeSpan connectorCycleTime) {
     this.connectorCycleTime = connectorCycleTime;
+  }
+
+  /**
+   * Sets the boolean flag indicating whether the connector should block data polling during each
+   * iteration of the main loop.
+   *
+   * <p>This flag is different from {@link #isDataPollingDisabled}, which indicates whether data
+   * polling has been disabled. This flag indicates whether data polling has been blocked due to a
+   * temporary condition or error.
+   *
+   * @param isDataPollingBlocked the boolean flag indicating whether the connector should block data
+   *     polling during each iteration of the main loop
+   * @since 1.15.12
+   */
+  public void setDataPollingBlocked(boolean isDataPollingBlocked) {
+    this.isDataPollingBlocked = isDataPollingBlocked;
   }
 
   /**
@@ -896,6 +925,8 @@ public abstract class AbstractConnectorMain {
         // Invoke connector data polling (if not disabled)
         if (isDataPollingDisabled) {
           Logger.LOG_DEBUG("Data polling is disabled and has been skipped.");
+        } else if (isDataPollingBlocked) {
+          Logger.LOG_DEBUG("Data polling is blocked and has been skipped.");
         } else {
           pollData();
         }

--- a/src/main/java/com/hms_networks/americas/sc/extensions/package.html
+++ b/src/main/java/com/hms_networks/americas/sc/extensions/package.html
@@ -5,7 +5,7 @@ environment by the HMS Networks, MU Americas Solution Center. These
 extension classes include many supplemental features, and the addition
 of new functionality which may not be present in the supported Java version.
 
-@version 1.15.11
+@version 1.15.12
 @author HMS Networks, MU Americas Solution Center
 </BODY>
 </HTML>

--- a/starting-files/jvmrun
+++ b/starting-files/jvmrun
@@ -1,1 +1,1 @@
--heapsize 25M -classpath /usr/extensions-1.15.11-full.jar -emain com.hms_networks.americas.sc.extensions.ExtensionsMain
+-heapsize 25M -classpath /usr/extensions-1.15.12-full.jar -emain com.hms_networks.americas.sc.extensions.ExtensionsMain

--- a/web-docs/docs/02-CHANGELOG.mdx
+++ b/web-docs/docs/02-CHANGELOG.mdx
@@ -50,7 +50,8 @@ toc_max_heading_level: 2
 
 ## Version 1.15.3
 ### Features
-- Added service timer to the application reboot watchdog to ensure application is in a stable state before allowing the watchdog to be serviced.
+- Added service timer to the application reboot watchdog to ensure application is in a stable state
+  before allowing the watchdog to be serviced.
 
 ## Version 1.15.2
 ### Features
@@ -84,14 +85,16 @@ toc_max_heading_level: 2
 
 ## Version 1.14.2
 ### Features
-- Added rapid catch up feature: this allows historical tracking to advance quickly for periods where the Flexy is offline.
+- Added rapid catch up feature: this allows historical tracking to advance quickly for periods where
+  the Flexy is offline.
 ### Bug Fixes
 - N/A
 
 ## Version 1.14.1
 ### Features
 - Added historical data queue diagnostic tag support to HistoricalDataQueueManager.java.
-  - Disabled by default. May be enabled using the `setEnableDiagnosticTags(boolean)` or `setEnableDiagnosticTags(boolean, long)` methods.
+  - Disabled by default. May be enabled using the `setEnableDiagnosticTags(boolean)`
+    or `setEnableDiagnosticTags(boolean, long)` methods.
   - Diagnostic tags are updated automatically after each historical data queue operation.
 ### Bug Fixes
 - N/A
@@ -120,12 +123,15 @@ toc_max_heading_level: 2
 - N/A
 ### Bug Fixes
 - Updated code formatting of files in JSON package to comply with Google Java Format v1.17.
-- Update HistoricalDataManager.java to detect EBD header using first non-zero length line encountered instead of static first line.
+- Update HistoricalDataManager.java to detect EBD header using first non-zero length line
+  encountered instead of static first line.
 
 ## Version 1.13.8
 ### Features
-- Updated SCAppManagement.enableAppAutoRestart() to return a boolean indicating if the auto-restart functionality was successfully enabled.
-- Added SCCountdownLatch.getCount() method to return the current count of the latch without blocking.
+- Updated SCAppManagement.enableAppAutoRestart() to return a boolean indicating if the auto-restart
+  functionality was successfully enabled.
+- Added SCCountdownLatch.getCount() method to return the current count of the latch without
+  blocking.
 ### Bug Fixes
 - N/A
 
@@ -139,7 +145,8 @@ toc_max_heading_level: 2
 ### Features
 - N/A
 ### Bug Fixes
-- Fixed an issue in ApplicationControlApiListener.java where constants were not properly scoped for access by subclasses.
+- Fixed an issue in ApplicationControlApiListener.java where constants were not properly scoped for
+  access by subclasses.
 
 ## Version 1.13.5
 ### Features
@@ -157,7 +164,8 @@ toc_max_heading_level: 2
 - Removed unsupported Java 7 references to the 'java.nio' package.
 - Removed try number increment in AutomaticRetryCode.getCurrentTryNumber().
 ### Other
-- Reduced default MQTT keep alive internal to from 60 to 10 seconds to detect connection issues faster.
+- Reduced default MQTT keep alive internal to from 60 to 10 seconds to detect connection issues
+  faster.
 
 ## Version 1.13.3
 ### Features
@@ -186,9 +194,12 @@ toc_max_heading_level: 2
 
 ## Version 1.13.0
 ### Features
-- Added HashUtilities.java class to allow for easy hashing (MD5 and SHA-1) of strings, files, and byte arrays.
-- Added SecurityProviderUtilites.java class to provide a simple API for adding and removing security providers in the JVM.
-- Added SCWonkaSecurityProvider.java class to allow access to the Wonka JVM MD5 and SHA-1 MessageDigest algorithms.
+- Added HashUtilities.java class to allow for easy hashing (MD5 and SHA-1) of strings, files, and
+  byte arrays.
+- Added SecurityProviderUtilites.java class to provide a simple API for adding and removing security
+  providers in the JVM.
+- Added SCWonkaSecurityProvider.java class to allow access to the Wonka JVM MD5 and SHA-1
+  MessageDigest algorithms.
   - SecurityProviderUtilities.java can be used to add SCWonkaSecurityProvider.java to the JVM.
 ### Bug Fixes
 - N/A

--- a/web-docs/docs/02-CHANGELOG.mdx
+++ b/web-docs/docs/02-CHANGELOG.mdx
@@ -5,6 +5,11 @@ sidebar_label: Change Log
 toc_max_heading_level: 2
 ---
 
+## Version 1.15.12
+### Features
+- Added support for blocking data polling in the abstract connector framework during temporary error
+  conditions
+
 ## Version 1.15.11
 ### Features
 - Added support for MQTT Will (Commonly referred to as LWT/Last Will and Testament)

--- a/web-docs/docs/_partial/_pom_library.mdx
+++ b/web-docs/docs/_partial/_pom_library.mdx
@@ -7,7 +7,7 @@ import ScDocusaurusConfig from "@site/ScDocusaurusConfig.js";
   <dependency>
     <groupId>com.hms_networks.americas.sc</groupId>
     <artifactId>extensions</artifactId>
-    <version>1.15.11</version>
+    <version>1.15.12</version>
   </dependency>
   ...
 </dependencies>


### PR DESCRIPTION
Added support for blocking data polling to the
connector framework. Data poll blocking is a
separate feature from enable/disable, as data
poll blocking is intended for temporary error
conditions, not a user selection via tag/API.