### PR TITLE
Release/1.16.0 pre2

### DIFF
--- a/src/main/java/com/hms_networks/americas/sc/extensions/datapoint/DataPoint.java
+++ b/src/main/java/com/hms_networks/americas/sc/extensions/datapoint/DataPoint.java
@@ -22,8 +22,22 @@ public abstract class DataPoint {
   /** Unit of data point tag. */
   protected String tagUnit;
 
-  /** Timestamp of data point */
+  /**
+   * Timestamp of data point in seconds since UNIX epoch. Note that timestamp could be relative to
+   * UTC or local time depending on Record Data in UTC setting. Please see <a
+   * href="https://hmsnetworks.blob.core.windows.net/www/docs/librariesprovider10/downloads-monitored/manuals/knowledge-base/kb-0284-01-en-utc-timestamp-logging.pdf">Knowledge
+   * base article on Flexy UTC historical logging setting</a> for details on historical data
+   * timestamp settings.
+   */
   protected String timestamp;
+
+  /**
+   * ISO 8601 format timestamp with millisecond resolution. Can be relative to UTC, or local time.
+   * Please see {@link
+   * com.hms_networks.americas.sc.extensions.historicaldata.HistoricalDataQueueManager} and
+   * exportDataInUtc parameter.
+   */
+  protected String iso8601Timestamp;
 
   /** Quality of data point value */
   protected DataQuality quality;
@@ -71,12 +85,29 @@ public abstract class DataPoint {
   }
 
   /**
-   * Get the {@link String} representation of the time stamp.
+   * Get the {@link String} representation of the UNIX epoch seconds timestamp. Because the
+   * timestamp could be in local time or UTC time, it is recommended to use {@link
+   * #getIso8601Timestamp} or {@link #getTimeStampAsDate} instead.
    *
    * @return the timestamp as a {@link String}.
+   * @deprecated - Use {@link #getIso8601Timestamp} or {@link #getTimeStampAsDate} instead.
    */
   public String getTimeStamp() {
     return timestamp;
+  }
+
+  /**
+   * Get the {@link String} representation of the ISO 8601 timestamp with milliseconds.
+   *
+   * <p>Example of local time offset: 2024-07-24T15:08:26.000-05:00
+   *
+   * <p>Example of UTC time: 2024-07-24T15:13:26.000Z
+   *
+   * @return the ISO 8601 timestamp as a {@link String}.
+   * @since 1.1.0
+   */
+  public String getIso8601Timestamp() {
+    return iso8601Timestamp;
   }
 
   /**

--- a/src/main/java/com/hms_networks/americas/sc/extensions/datapoint/DataPointBoolean.java
+++ b/src/main/java/com/hms_networks/americas/sc/extensions/datapoint/DataPointBoolean.java
@@ -20,16 +20,24 @@ public class DataPointBoolean extends DataPoint {
    * @param tagId data point tag ID
    * @param tagUnit data point tag unit
    * @param value data point value
-   * @param time data point timestamp
+   * @param time data point timestamp, UNIX epoch seconds
+   * @param timeIso8601 data point timestamp, ISO 8601 format
    * @param quality data point quality
    */
   public DataPointBoolean(
-      String tagName, int tagId, String tagUnit, boolean value, String time, DataQuality quality) {
+      String tagName,
+      int tagId,
+      String tagUnit,
+      boolean value,
+      String time,
+      String timeIso8601,
+      DataQuality quality) {
     this.tagName = tagName;
     this.tagId = tagId;
     this.tagUnit = tagUnit;
     this.value = value;
     this.timestamp = time;
+    this.iso8601Timestamp = timeIso8601;
     this.quality = quality;
   }
 
@@ -40,14 +48,17 @@ public class DataPointBoolean extends DataPoint {
    * @param tagId data point tag ID
    * @param tagUnit data point unit
    * @param value data point value
-   * @param time data point timestamp
+   * @param time data point timestamp, UNIX epoch seconds
+   * @param timeIso8601 data point timestamp, ISO 8601 format
    */
-  public DataPointBoolean(String tagName, int tagId, String tagUnit, boolean value, String time) {
+  public DataPointBoolean(
+      String tagName, int tagId, String tagUnit, boolean value, String time, String timeIso8601) {
     this.tagName = tagName;
     this.tagId = tagId;
     this.tagUnit = tagUnit;
     this.value = value;
     this.timestamp = time;
+    this.iso8601Timestamp = timeIso8601;
     this.quality = DataQuality.GOOD;
   }
 
@@ -126,6 +137,7 @@ public class DataPointBoolean extends DataPoint {
    * @throws CloneNotSupportedException if the data point cannot be cloned
    */
   public DataPoint clone(String tagName) throws CloneNotSupportedException {
-    return new DataPointBoolean(tagName, tagId, tagUnit, value, timestamp, quality);
+    return new DataPointBoolean(
+        tagName, tagId, tagUnit, value, timestamp, iso8601Timestamp, quality);
   }
 }

--- a/src/main/java/com/hms_networks/americas/sc/extensions/datapoint/DataPointDword.java
+++ b/src/main/java/com/hms_networks/americas/sc/extensions/datapoint/DataPointDword.java
@@ -20,16 +20,24 @@ public class DataPointDword extends DataPoint {
    * @param tagId data point tag ID
    * @param tagUnit data point tag unit
    * @param value data point value
-   * @param time data point timestamp
+   * @param time data point timestamp, UNIX epoch seconds
+   * @param timeIso8601 data point timestamp, ISO 8601 format
    * @param quality data point quality
    */
   public DataPointDword(
-      String tagName, int tagId, String tagUnit, long value, String time, DataQuality quality) {
+      String tagName,
+      int tagId,
+      String tagUnit,
+      long value,
+      String time,
+      String timeIso8601,
+      DataQuality quality) {
     this.tagName = tagName;
     this.tagId = tagId;
     this.tagUnit = tagUnit;
     this.value = value;
     this.timestamp = time;
+    this.iso8601Timestamp = timeIso8601;
     this.quality = quality;
   }
 
@@ -40,14 +48,17 @@ public class DataPointDword extends DataPoint {
    * @param tagId data point tag ID
    * @param tagUnit data point tag unit
    * @param value data point value
-   * @param time data point timestamp
+   * @param time data point timestamp, UNIX epoch seconds
+   * @param timeIso8601 data point timestamp, ISO 8601 format
    */
-  public DataPointDword(String tagName, int tagId, String tagUnit, long value, String time) {
+  public DataPointDword(
+      String tagName, int tagId, String tagUnit, long value, String time, String timeIso8601) {
     this.tagName = tagName;
     this.tagId = tagId;
     this.tagUnit = tagUnit;
     this.value = value;
     this.timestamp = time;
+    this.iso8601Timestamp = timeIso8601;
     this.quality = DataQuality.GOOD;
   }
 
@@ -126,6 +137,6 @@ public class DataPointDword extends DataPoint {
    * @throws CloneNotSupportedException if the data point cannot be cloned
    */
   public DataPoint clone(String tagName) throws CloneNotSupportedException {
-    return new DataPointDword(tagName, tagId, tagUnit, value, timestamp, quality);
+    return new DataPointDword(tagName, tagId, tagUnit, value, timestamp, iso8601Timestamp, quality);
   }
 }

--- a/src/main/java/com/hms_networks/americas/sc/extensions/datapoint/DataPointFloat.java
+++ b/src/main/java/com/hms_networks/americas/sc/extensions/datapoint/DataPointFloat.java
@@ -20,16 +20,24 @@ public class DataPointFloat extends DataPoint {
    * @param tagId data point tag ID
    * @param tagUnit data point tag unit
    * @param value data point value
-   * @param time data point timestamp
+   * @param time data point timestamp, UNIX epoch seconds
+   * @param timeIso8601 data point timestamp, ISO 8601 format
    * @param quality data point quality
    */
   public DataPointFloat(
-      String tagName, int tagId, String tagUnit, float value, String time, DataQuality quality) {
+      String tagName,
+      int tagId,
+      String tagUnit,
+      float value,
+      String time,
+      String timeIso8601,
+      DataQuality quality) {
     this.tagName = tagName;
     this.tagId = tagId;
     this.tagUnit = tagUnit;
     this.value = value;
     this.timestamp = time;
+    this.iso8601Timestamp = timeIso8601;
     this.quality = quality;
   }
 
@@ -40,14 +48,17 @@ public class DataPointFloat extends DataPoint {
    * @param tagId data point tag ID
    * @param tagUnit data point tag unit
    * @param value data point value
-   * @param time data point timestamp
+   * @param time data point timestamp, UNIX epoch seconds
+   * @param timeIso8601 data point timestamp, ISO 8601 format
    */
-  public DataPointFloat(String tagName, int tagId, String tagUnit, float value, String time) {
+  public DataPointFloat(
+      String tagName, int tagId, String tagUnit, float value, String time, String timeIso8601) {
     this.tagName = tagName;
     this.tagId = tagId;
     this.tagUnit = tagUnit;
     this.value = value;
     this.timestamp = time;
+    this.iso8601Timestamp = timeIso8601;
     this.quality = DataQuality.GOOD;
   }
 
@@ -126,6 +137,6 @@ public class DataPointFloat extends DataPoint {
    * @throws CloneNotSupportedException if the data point cannot be cloned
    */
   public DataPoint clone(String tagName) throws CloneNotSupportedException {
-    return new DataPointFloat(tagName, tagId, tagUnit, value, timestamp, quality);
+    return new DataPointFloat(tagName, tagId, tagUnit, value, timestamp, iso8601Timestamp, quality);
   }
 }

--- a/src/main/java/com/hms_networks/americas/sc/extensions/datapoint/DataPointInteger.java
+++ b/src/main/java/com/hms_networks/americas/sc/extensions/datapoint/DataPointInteger.java
@@ -20,16 +20,24 @@ public class DataPointInteger extends DataPoint {
    * @param tagId data point tag ID
    * @param tagUnit data point tag Unit
    * @param value data point value
-   * @param time data point timestamp
+   * @param time data point timestamp, UNIX epoch seconds
+   * @param timeIso8601 data point timestamp, ISO 8601 format
    * @param quality data point quality
    */
   public DataPointInteger(
-      String tagName, int tagId, String tagUnit, int value, String time, DataQuality quality) {
+      String tagName,
+      int tagId,
+      String tagUnit,
+      int value,
+      String time,
+      String timeIso8601,
+      DataQuality quality) {
     this.tagName = tagName;
     this.tagId = tagId;
     this.tagUnit = tagUnit;
     this.value = value;
     this.timestamp = time;
+    this.iso8601Timestamp = timeIso8601;
     this.quality = quality;
   }
 
@@ -40,14 +48,17 @@ public class DataPointInteger extends DataPoint {
    * @param tagId data point tag ID
    * @param tagUnit data point tag Unit
    * @param value data point value
-   * @param time data point timestamp
+   * @param time data point timestamp, UNIX epoch seconds
+   * @param timeIso8601 data point timestamp, ISO 8601 format
    */
-  public DataPointInteger(String tagName, int tagId, String tagUnit, int value, String time) {
+  public DataPointInteger(
+      String tagName, int tagId, String tagUnit, int value, String time, String timeIso8601) {
     this.tagName = tagName;
     this.tagId = tagId;
     this.tagUnit = tagUnit;
     this.value = value;
     this.timestamp = time;
+    this.iso8601Timestamp = timeIso8601;
     this.quality = DataQuality.GOOD;
   }
 
@@ -126,6 +137,7 @@ public class DataPointInteger extends DataPoint {
    * @throws CloneNotSupportedException if the data point cannot be cloned
    */
   public DataPoint clone(String tagName) throws CloneNotSupportedException {
-    return new DataPointInteger(tagName, tagId, tagUnit, value, timestamp, quality);
+    return new DataPointInteger(
+        tagName, tagId, tagUnit, value, timestamp, iso8601Timestamp, quality);
   }
 }

--- a/src/main/java/com/hms_networks/americas/sc/extensions/datapoint/DataPointIntegerMappedString.java
+++ b/src/main/java/com/hms_networks/americas/sc/extensions/datapoint/DataPointIntegerMappedString.java
@@ -25,7 +25,8 @@ public class DataPointIntegerMappedString extends DataPointString {
    * @param tagId data point tag ID
    * @param tagUnit data point tag unit
    * @param value data point value
-   * @param time data point timestamp
+   * @param time data point timestamp, UNIX epoch seconds
+   * @param timeIso8601 data point timestamp, ISO 8601 format
    * @param quality data point quality
    * @param enumMapping integer enumerated {@link String} mapping(s)
    */
@@ -35,9 +36,10 @@ public class DataPointIntegerMappedString extends DataPointString {
       String tagUnit,
       int value,
       String time,
+      String timeIso8601,
       DataQuality quality,
       String[] enumMapping) {
-    super(tagName, tagId, tagUnit, enumMapping[value], time, quality);
+    super(tagName, tagId, tagUnit, enumMapping[value], time, timeIso8601, quality);
   }
 
   /**
@@ -48,12 +50,19 @@ public class DataPointIntegerMappedString extends DataPointString {
    * @param tagId data point tag ID
    * @param tagUnit data point tag Unit
    * @param value data point value
-   * @param time data point timestamp
+   * @param time data point timestamp, UNIX epoch seconds
+   * @param timeIso8601 data point timestamp, ISO 8601 format
    * @param enumMapping integer enumerated {@link String} mapping(s)
    */
   public DataPointIntegerMappedString(
-      String tagName, int tagId, String tagUnit, int value, String time, String[] enumMapping) {
-    super(tagName, tagId, tagUnit, enumMapping[value], time);
+      String tagName,
+      int tagId,
+      String tagUnit,
+      int value,
+      String time,
+      String timeIso8601,
+      String[] enumMapping) {
+    super(tagName, tagId, tagUnit, enumMapping[value], time, timeIso8601);
   }
 
   /**

--- a/src/main/java/com/hms_networks/americas/sc/extensions/datapoint/DataPointNumber.java
+++ b/src/main/java/com/hms_networks/americas/sc/extensions/datapoint/DataPointNumber.java
@@ -20,16 +20,24 @@ public class DataPointNumber extends DataPoint {
    * @param tagId data point tag ID
    * @param tagUnit data point tag Unit
    * @param value data point value
-   * @param time data point timestamp
+   * @param time data point timestamp, UNIX epoch seconds
+   * @param timeIso8601 data point timestamp, ISO 8601 format
    * @param quality data point quality
    */
   public DataPointNumber(
-      String tagName, int tagId, String tagUnit, Number value, String time, DataQuality quality) {
+      String tagName,
+      int tagId,
+      String tagUnit,
+      Number value,
+      String time,
+      String timeIso8601,
+      DataQuality quality) {
     this.tagName = tagName;
     this.tagId = tagId;
     this.tagUnit = tagUnit;
     this.value = value;
     this.timestamp = time;
+    this.iso8601Timestamp = timeIso8601;
     this.quality = quality;
   }
 
@@ -41,13 +49,16 @@ public class DataPointNumber extends DataPoint {
    * @param tagUnit data point tag Unit
    * @param value data point value
    * @param time data point timestamp
+   * @param timeIso8601 data point timestamp, ISO 8601 format
    */
-  public DataPointNumber(String tagName, int tagId, String tagUnit, Number value, String time) {
+  public DataPointNumber(
+      String tagName, int tagId, String tagUnit, Number value, String time, String timeIso8601) {
     this.tagName = tagName;
     this.tagId = tagId;
     this.tagUnit = tagUnit;
     this.value = value;
     this.timestamp = time;
+    this.iso8601Timestamp = timeIso8601;
     this.quality = DataQuality.GOOD;
   }
 
@@ -143,6 +154,7 @@ public class DataPointNumber extends DataPoint {
    * @throws CloneNotSupportedException if the data point cannot be cloned
    */
   public DataPoint clone(String tagName) throws CloneNotSupportedException {
-    return new DataPointNumber(tagName, tagId, tagUnit, value, timestamp, quality);
+    return new DataPointNumber(
+        tagName, tagId, tagUnit, value, timestamp, iso8601Timestamp, quality);
   }
 }

--- a/src/main/java/com/hms_networks/americas/sc/extensions/datapoint/DataPointString.java
+++ b/src/main/java/com/hms_networks/americas/sc/extensions/datapoint/DataPointString.java
@@ -20,16 +20,24 @@ public class DataPointString extends DataPoint {
    * @param tagId data point tag ID
    * @param tagUnit data point tag Unit
    * @param value data point value
-   * @param time data point timestamp
+   * @param time data point timestamp, UNIX epoch seconds
+   * @param timeIso8601 data point timestamp, ISO 8601 format
    * @param quality data point quality
    */
   public DataPointString(
-      String tagName, int tagId, String tagUnit, String value, String time, DataQuality quality) {
+      String tagName,
+      int tagId,
+      String tagUnit,
+      String value,
+      String time,
+      String timeIso8601,
+      DataQuality quality) {
     this.tagName = tagName;
     this.tagId = tagId;
     this.tagUnit = tagUnit;
     this.value = value;
     this.timestamp = time;
+    this.iso8601Timestamp = timeIso8601;
     this.quality = quality;
   }
 
@@ -40,14 +48,17 @@ public class DataPointString extends DataPoint {
    * @param tagId data point tag ID
    * @param tagUnit data point tag Unit
    * @param value data point value
-   * @param time data point timestamp
+   * @param time data point timestamp, UNIX epoch seconds
+   * @param timeIso8601 data point timestamp, ISO 8601 format
    */
-  public DataPointString(String tagName, int tagId, String tagUnit, String value, String time) {
+  public DataPointString(
+      String tagName, int tagId, String tagUnit, String value, String time, String timeIso8601) {
     this.tagName = tagName;
     this.tagId = tagId;
     this.tagUnit = tagUnit;
     this.value = value;
     this.timestamp = time;
+    this.iso8601Timestamp = timeIso8601;
     this.quality = DataQuality.GOOD;
   }
 
@@ -126,6 +137,7 @@ public class DataPointString extends DataPoint {
    * @throws CloneNotSupportedException if the data point cannot be cloned
    */
   public DataPoint clone(String tagName) throws CloneNotSupportedException {
-    return new DataPointString(tagName, tagId, tagUnit, value, timestamp, quality);
+    return new DataPointString(
+        tagName, tagId, tagUnit, value, timestamp, iso8601Timestamp, quality);
   }
 }

--- a/src/main/java/com/hms_networks/americas/sc/extensions/historicaldata/HistoricalDataConstants.java
+++ b/src/main/java/com/hms_networks/americas/sc/extensions/historicaldata/HistoricalDataConstants.java
@@ -19,6 +19,9 @@ class HistoricalDataConstants {
   /** Index of time int in EBD lines */
   public static final int EBD_LINE_TAG_TIMEINT_INDEX = 1;
 
+  /** Index of time string in EBD lines */
+  public static final int EBD_LINE_TAG_TIMESTR_INDEX = 2;
+
   /** Index of tag value in EBD lines */
   public static final int EBD_LINE_TAG_VALUE_INDEX = 4;
 
@@ -145,4 +148,13 @@ class HistoricalDataConstants {
 
   /** The IO server used for queue diagnostic tag(s). */
   public static final String QUEUE_DIAGNOSTIC_TAG_IO_SERVER = "MEM";
+
+  /** Start index of the actual ISO 8601 timestamp return by EBD. */
+  public static final int EBD_ISO8601_TIMESTAMP_START_INDEX = 1;
+
+  /** String index where milliseconds should be added to a timestamp that lacks milliseconds. */
+  public static final int EBD_ISO8601_TIMESTAMP_START_MILLIS = 20;
+
+  /** String to add to a timestamp that lacks milliseconds. */
+  public static final String EBD_ISO8601_TIMESTAMP_ADD_MILLIS_STR = ".000";
 }

--- a/src/main/java/com/hms_networks/americas/sc/extensions/historicaldata/HistoricalDataManager.java
+++ b/src/main/java/com/hms_networks/americas/sc/extensions/historicaldata/HistoricalDataManager.java
@@ -29,12 +29,23 @@ import java.util.Map;
  *
  * @author HMS Networks, MU Americas Solution Center
  * @since 1.0.0
+ * @version 3.0.0
  */
 public class HistoricalDataManager {
 
   /**
+   * Default value for the export data in UTC flag. This is separate from the Ewon's export data in
+   * UTC setting, and is used when the value is not specified.
+   */
+  private static final boolean DEFAULT_EXPORT_DATA_IN_UTC = true;
+
+  /**
    * Reads historical log between <code>startTime</code> and <code>endTime</code>. Returns a list of
    * data points.
+   *
+   * <p>In version 3.0.0 and later, this method returns data points with an ISO 8601 formatted
+   * timestamp. Previous versions used a timestamp integer with the number of seconds since epoch,
+   * thus callers of this method must adapt as necessary.
    *
    * @param startTime start time of export
    * @param endTime end time of export
@@ -47,6 +58,9 @@ public class HistoricalDataManager {
    * @throws IOException if export block descriptor fails
    * @throws JSONException if unable to parse int to string enumeration file
    * @throws EbdTimeoutException for EBD timeout
+   * @since 1.0.0
+   * @deprecated Use {@link #readHistoricalFifo(String, String, boolean, boolean, boolean, boolean,
+   *     boolean, boolean)} instead.
    */
   public static ArrayList readHistoricalFifo(
       String startTime,
@@ -56,6 +70,49 @@ public class HistoricalDataManager {
       boolean includeTagGroupC,
       boolean includeTagGroupD,
       boolean stringHistorical)
+      throws IOException, JSONException, EbdTimeoutException {
+    return readHistoricalFifo(
+        startTime,
+        endTime,
+        includeTagGroupA,
+        includeTagGroupB,
+        includeTagGroupC,
+        includeTagGroupD,
+        stringHistorical,
+        DEFAULT_EXPORT_DATA_IN_UTC);
+  }
+
+  /**
+   * Reads historical log between <code>startTime</code> and <code>endTime</code>. Returns a list of
+   * data points.
+   *
+   * <p>In version 3.0.0 and later, this method returns data points with an ISO 8601 formatted
+   * timestamp. Previous versions used a timestamp integer with the number of seconds since epoch,
+   * thus callers of this method must adapt as necessary.
+   *
+   * @param startTime start time of export
+   * @param endTime end time of export
+   * @param includeTagGroupA include tag group A
+   * @param includeTagGroupB include tag group B
+   * @param includeTagGroupC include tag group C
+   * @param includeTagGroupD include tag group D
+   * @param stringHistorical export string historical logs if true
+   * @param exportDataInUtc export data in ISO 8601 UTC format if {@code true} (instead of local)
+   * @return data points from response
+   * @throws IOException if export block descriptor fails
+   * @throws JSONException if unable to parse int to string enumeration file
+   * @throws EbdTimeoutException for EBD timeout
+   * @since 3.0.0
+   */
+  public static ArrayList readHistoricalFifo(
+      String startTime,
+      String endTime,
+      boolean includeTagGroupA,
+      boolean includeTagGroupB,
+      boolean includeTagGroupC,
+      boolean includeTagGroupD,
+      boolean stringHistorical,
+      boolean exportDataInUtc)
       throws IOException, JSONException, EbdTimeoutException {
 
     // create EBD string
@@ -67,7 +124,8 @@ public class HistoricalDataManager {
             includeTagGroupB,
             includeTagGroupC,
             includeTagGroupD,
-            stringHistorical);
+            stringHistorical,
+            exportDataInUtc);
 
     // Execute EBD call and parse results
     final Exporter exporter = executeEbdCall(ebdStr);
@@ -78,6 +136,10 @@ public class HistoricalDataManager {
    * Reads historical log between <code>startTime</code> and <code>endTime</code>. Returns a map of
    * rounded timestamps to lists of data points. <br>
    * (Parameterized map type: Map&lt;Date, List&lt;DataPoint&gt;&gt;)
+   *
+   * <p>In version 3.0.0 and later, this method returns data points with an ISO 8601 formatted
+   * timestamp. Previous versions used a timestamp integer with the number of seconds since epoch,
+   * thus callers of this method must adapt as necessary.
    *
    * @param startTime start time of export
    * @param endTime end time of export
@@ -93,6 +155,9 @@ public class HistoricalDataManager {
    * @throws EbdTimeoutException for EBD timeout
    * @throws IllegalArgumentException if time unit is null, unknown, or not supported
    * @throws Exception if unable to parse data point timestamp to date
+   * @since 1.0.0
+   * @deprecated Use {@link #readHistoricalFifo(String, String, boolean, boolean, boolean, boolean,
+   *     boolean, boolean, SCTimeSpan)} instead.
    */
   public static Map readHistoricalFifo(
       String startTime,
@@ -102,6 +167,55 @@ public class HistoricalDataManager {
       boolean includeTagGroupC,
       boolean includeTagGroupD,
       boolean stringHistorical,
+      SCTimeSpan timeSpan)
+      throws Exception {
+    return readHistoricalFifo(
+        startTime,
+        endTime,
+        includeTagGroupA,
+        includeTagGroupB,
+        includeTagGroupC,
+        includeTagGroupD,
+        stringHistorical,
+        DEFAULT_EXPORT_DATA_IN_UTC,
+        timeSpan);
+  }
+
+  /**
+   * Reads historical log between <code>startTime</code> and <code>endTime</code>. Returns a map of
+   * rounded timestamps to lists of data points. <br>
+   * (Parameterized map type: Map&lt;Date, List&lt;DataPoint&gt;&gt;)
+   *
+   * <p>In version 3.0.0 and later, this method returns data points with an ISO 8601 formatted
+   * timestamp. Previous versions used a timestamp integer with the number of seconds since epoch,
+   * thus callers of this method must adapt as necessary.
+   *
+   * @param startTime start time of export
+   * @param endTime end time of export
+   * @param includeTagGroupA include tag group A
+   * @param includeTagGroupB include tag group B
+   * @param includeTagGroupC include tag group C
+   * @param includeTagGroupD include tag group D
+   * @param stringHistorical export string historical logs if true
+   * @param exportDataInUtc export data in ISO 8601 UTC format if {@code true} (instead of local)
+   * @param timeSpan time span to round data point time stamps to
+   * @return data points from response
+   * @throws IOException if export block descriptor fails
+   * @throws JSONException if unable to parse int to string enumeration file
+   * @throws EbdTimeoutException for EBD timeout
+   * @throws IllegalArgumentException if time unit is null, unknown, or not supported
+   * @throws Exception if unable to parse data point timestamp to date
+   * @since 3.0.0
+   */
+  public static Map readHistoricalFifo(
+      String startTime,
+      String endTime,
+      boolean includeTagGroupA,
+      boolean includeTagGroupB,
+      boolean includeTagGroupC,
+      boolean includeTagGroupD,
+      boolean stringHistorical,
+      boolean exportDataInUtc,
       SCTimeSpan timeSpan)
       throws Exception {
 
@@ -114,7 +228,8 @@ public class HistoricalDataManager {
             includeTagGroupB,
             includeTagGroupC,
             includeTagGroupD,
-            stringHistorical);
+            stringHistorical,
+            exportDataInUtc);
 
     // Execute EBD call and parse results
     final Exporter exporter = executeEbdCall(ebdStr);
@@ -128,6 +243,7 @@ public class HistoricalDataManager {
    * @return EBD Exporter - caller must close exporter
    * @throws EbdTimeoutException when there is no response before timeout period
    * @throws IOException when there is an Exporter Exception
+   * @since 1.0.0
    */
   public static Exporter executeEbdCall(String ebdStr) throws IOException, EbdTimeoutException {
     final long start = System.currentTimeMillis();
@@ -163,7 +279,9 @@ public class HistoricalDataManager {
    * @param includeTagGroupC include tag group C
    * @param includeTagGroupD include tag group D
    * @param stringHistorical export string historical logs if true
+   * @param exportDataInUtc export data in ISO 8601 UTC format if {@code true} (instead of local)
    * @return EBD string
+   * @since 1.0.0
    */
   static String prepareHistoricalFifoReadEBDString(
       String startTime,
@@ -172,7 +290,8 @@ public class HistoricalDataManager {
       boolean includeTagGroupB,
       boolean includeTagGroupC,
       boolean includeTagGroupD,
-      boolean stringHistorical) {
+      boolean stringHistorical,
+      boolean exportDataInUtc) {
 
     // Check for valid group selection
     if (!includeTagGroupA && !includeTagGroupB && !includeTagGroupC && !includeTagGroupD) {
@@ -203,12 +322,21 @@ public class HistoricalDataManager {
       ebdDataType = "HL";
     }
 
+    // Get EBD timestamp type
+    String ebdTimestampType;
+    if (exportDataInUtc) {
+      ebdTimestampType = "U";
+    } else {
+      ebdTimestampType = "L";
+    }
+
     /*
      * Build EBD string with parameters
      * dt[ebdDataType]: data type, value specified in string ebdDataType
      * ftT: file type, text
      * startTime: start time for data
      * endTime: end time for data
+     * ts: timestamp type, value specified in string ebdTimestampType
      * flABCD: filter type, specified tag groups
      */
     return "$dt"
@@ -217,6 +345,8 @@ public class HistoricalDataManager {
         + startTime
         + "$et"
         + endTime
+        + "$ts"
+        + ebdTimestampType
         + "$fl"
         + tagGroupFilterStr;
   }
@@ -225,10 +355,14 @@ public class HistoricalDataManager {
    * Parses Export Block Descriptor Historical Log response into a list of data points. Note: this
    * function only handles Historical Log responses.
    *
+   * <p>In version 3.0.0 and later, this method returns data points with an ISO 8601 formatted
+   * timestamp in addition to the timestamp integer with the number of seconds since epoch.
+   *
    * @param exporter EBD Exporter
    * @return a list of data points from the response
    * @throws IOException for parsing Exceptions
    * @throws JSONException for JSON parsing Exceptions
+   * @since 1.0.0
    */
   private static ArrayList parseEBDHistoricalLogExportResponse(Exporter exporter)
       throws IOException, JSONException {
@@ -254,6 +388,9 @@ public class HistoricalDataManager {
    * lists of data points. Note: this function only handles Historical Log responses. <br>
    * (Parameterized map type: Map&lt;Date, List&lt;DataPoint&gt;&gt;)
    *
+   * <p>In version 3.0.0 and later, this method returns data points with an ISO 8601 formatted
+   * timestamp in addition to the timestamp integer with the number of seconds since epoch.
+   *
    * @param exporter EBD Exporter
    * @param timeSpan time span to round data point time stamps to
    * @return a map of data points and time stamps from the response
@@ -261,6 +398,7 @@ public class HistoricalDataManager {
    * @throws JSONException for JSON parsing Exceptions
    * @throws IllegalArgumentException if time unit is null, unknown, or not supported
    * @throws Exception if unable to parse data point timestamp to date
+   * @since 2.0.0
    */
   private static Map parseEBDHistoricalLogExportResponse(Exporter exporter, SCTimeSpan timeSpan)
       throws Exception {
@@ -305,29 +443,53 @@ public class HistoricalDataManager {
    *
    * @param strBool boolean string representation
    * @return converted boolean
+   * @since 1.0.0
    */
   private static boolean convertStrToBool(String strBool) {
     return strBool.equals("1");
   }
 
   /**
+   * Corrects the Export Block Descriptor (EBD) ISO 8601 timestamp by removing quotes and adding
+   * milliseconds to the timestamp.
+   *
+   * <p>Example: "2020-02-24T15:20:58Z" to 2020-02-24T15:20:58.000Z
+   *
+   * @param ebdTs Export ISO 8601 timestamp
+   * @return corrected ISO 8601 timestamp
+   */
+  private static String correctEbdIsoTimestamp(String ebdTs) {
+    return ebdTs.substring(
+            HistoricalDataConstants.EBD_ISO8601_TIMESTAMP_START_INDEX,
+            HistoricalDataConstants.EBD_ISO8601_TIMESTAMP_START_MILLIS)
+        + HistoricalDataConstants.EBD_ISO8601_TIMESTAMP_ADD_MILLIS_STR
+        + ebdTs.substring(
+            HistoricalDataConstants.EBD_ISO8601_TIMESTAMP_START_MILLIS, ebdTs.length() - 1);
+  }
+
+  /**
    * Parse the specified historical file line and return its corresponding data point.
+   *
+   * <p>In version 3.0.0 and later, this method returns a data point with an ISO 8601 formatted
+   * timestamp in addition to a timestamp integer with the number of seconds since epoch.
    *
    * @param line line to parse
    * @return data point
    * @throws IOException if unable to access tag information
    * @throws JSONException if unable to parse int to string enumeration file
+   * @since 1.0.0
    */
   static DataPoint parseHistoricalFileLine(String line) throws IOException, JSONException {
     /*
      * Example Line:
      * "TagId";"TimeInt";"TimeStr";"IsInitValue";"Value";"IQuality"
-     * 247;1582557658;"24/02/2020 15:20:58";0;0;3
+     * 3;1721834576;"2024-07-24T15:22:56-05:00";0;43;3
      */
 
     // Create variables to store line data
     int tagId = -1;
-    String tagTimeInt = "";
+    String tagTimeEpochStr = "";
+    String tagTimeIso8601Str = "";
     String tagValue = "";
     int tagQuality = DataQuality.GOOD.getRawDataQuality();
 
@@ -355,7 +517,10 @@ public class HistoricalDataManager {
           tagId = Integer.parseInt(currentToken);
           break;
         case HistoricalDataConstants.EBD_LINE_TAG_TIMEINT_INDEX:
-          tagTimeInt = currentToken;
+          tagTimeEpochStr = currentToken;
+          break;
+        case HistoricalDataConstants.EBD_LINE_TAG_TIMESTR_INDEX:
+          tagTimeIso8601Str = correctEbdIsoTimestamp(currentToken);
           break;
         case HistoricalDataConstants.EBD_LINE_TAG_VALUE_INDEX:
           tagValue = currentToken;
@@ -388,7 +553,14 @@ public class HistoricalDataManager {
             if (tagType == TagType.BOOLEAN) {
               boolean boolValue = convertStrToBool(tagValue);
               returnVal =
-                  new DataPointBoolean(tagName, tagId, tagUnit, boolValue, tagTimeInt, dataQuality);
+                  new DataPointBoolean(
+                      tagName,
+                      tagId,
+                      tagUnit,
+                      boolValue,
+                      tagTimeEpochStr,
+                      tagTimeIso8601Str,
+                      dataQuality);
             } else if (tagType == TagType.FLOAT) {
               float floatValue;
               if (tagValue.equalsIgnoreCase(HistoricalDataConstants.TAG_VALUE_NEGATIVE_INFINITY)) {
@@ -402,11 +574,25 @@ public class HistoricalDataManager {
                 floatValue = Float.valueOf(tagValue).floatValue();
               }
               returnVal =
-                  new DataPointFloat(tagName, tagId, tagUnit, floatValue, tagTimeInt, dataQuality);
+                  new DataPointFloat(
+                      tagName,
+                      tagId,
+                      tagUnit,
+                      floatValue,
+                      tagTimeEpochStr,
+                      tagTimeIso8601Str,
+                      dataQuality);
             } else if (tagType == TagType.INTEGER) {
               int intValue = Integer.valueOf(tagValue).intValue();
               returnVal =
-                  new DataPointInteger(tagName, tagId, tagUnit, intValue, tagTimeInt, dataQuality);
+                  new DataPointInteger(
+                      tagName,
+                      tagId,
+                      tagUnit,
+                      intValue,
+                      tagTimeEpochStr,
+                      tagTimeIso8601Str,
+                      dataQuality);
             } else if (tagType == TagType.INTEGER_MAPPED_STRING) {
               int intValue = Integer.valueOf(tagValue).intValue();
               TagInfoEnumeratedIntToString tagInfoEnumeratedIntToString =
@@ -417,16 +603,31 @@ public class HistoricalDataManager {
                       tagId,
                       tagUnit,
                       intValue,
-                      tagTimeInt,
+                      tagTimeEpochStr,
+                      tagTimeIso8601Str,
                       dataQuality,
                       tagInfoEnumeratedIntToString.getEnumeratedStringValueMapping());
             } else if (tagType == TagType.DWORD) {
               long dwordValue = Long.valueOf(tagValue).longValue();
               returnVal =
-                  new DataPointDword(tagName, tagId, tagUnit, dwordValue, tagTimeInt, dataQuality);
+                  new DataPointDword(
+                      tagName,
+                      tagId,
+                      tagUnit,
+                      dwordValue,
+                      tagTimeEpochStr,
+                      tagTimeIso8601Str,
+                      dataQuality);
             } else if (tagType == TagType.STRING) {
               returnVal =
-                  new DataPointString(tagName, tagId, tagUnit, tagValue, tagTimeInt, dataQuality);
+                  new DataPointString(
+                      tagName,
+                      tagId,
+                      tagUnit,
+                      tagValue,
+                      tagTimeEpochStr,
+                      tagTimeIso8601Str,
+                      dataQuality);
             }
           }
       }

--- a/src/main/java/com/hms_networks/americas/sc/extensions/historicaldata/HistoricalDataQueueManager.java
+++ b/src/main/java/com/hms_networks/americas/sc/extensions/historicaldata/HistoricalDataQueueManager.java
@@ -5,6 +5,7 @@ import com.hms_networks.americas.sc.extensions.fileutils.FileAccessManager;
 import com.hms_networks.americas.sc.extensions.json.JSONException;
 import com.hms_networks.americas.sc.extensions.system.time.SCTimeSpan;
 import com.hms_networks.americas.sc.extensions.system.time.SCTimeUnit;
+import com.hms_networks.americas.sc.extensions.system.time.SCTimeUtils;
 import java.io.File;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
@@ -627,6 +628,9 @@ public class HistoricalDataQueueManager {
     long startTimeTrackerMsPlusSpan = startTimeTrackerMsLong + getQueueFifoTimeSpanMillis();
     long endTimeTrackerMsLong = Math.min(startTimeTrackerMsPlusSpan, System.currentTimeMillis());
 
+    // Get export data in UTC time setting
+    boolean exportDataInUtc = SCTimeUtils.getTagDataExportedInUtc();
+
     ArrayList queueDataList = null;
     Map queueDataMap = null;
 
@@ -641,7 +645,8 @@ public class HistoricalDataQueueManager {
               includeTagGroupB,
               includeTagGroupC,
               includeTagGroupD,
-              stringHistorical);
+              stringHistorical,
+              exportDataInUtc);
 
       if (catchUpResult.isHistoricalTrackingCaughtUp()) {
         // If historical tracking is caught up, set lastReadDataPointsEmpty to false
@@ -679,6 +684,7 @@ public class HistoricalDataQueueManager {
                 includeTagGroupC,
                 includeTagGroupD,
                 stringHistorical,
+                exportDataInUtc,
                 timeSpan);
       } else {
         queueDataList =
@@ -689,7 +695,8 @@ public class HistoricalDataQueueManager {
                 includeTagGroupB,
                 includeTagGroupC,
                 includeTagGroupD,
-                stringHistorical);
+                stringHistorical,
+                exportDataInUtc);
       }
 
       // Run string EBD export call if enabled
@@ -706,6 +713,7 @@ public class HistoricalDataQueueManager {
                   includeTagGroupC,
                   includeTagGroupD,
                   stringHistorical,
+                  exportDataInUtc,
                   timeSpan);
 
           // Combine with standard EBD call results
@@ -736,7 +744,8 @@ public class HistoricalDataQueueManager {
                   includeTagGroupB,
                   includeTagGroupC,
                   includeTagGroupD,
-                  stringHistorical);
+                  stringHistorical,
+                  exportDataInUtc);
 
           // Combine with standard EBD call results
           queueDataList.addAll(queueStringDataList);

--- a/src/main/java/com/hms_networks/americas/sc/extensions/historicaldata/RapidCatchUp.java
+++ b/src/main/java/com/hms_networks/americas/sc/extensions/historicaldata/RapidCatchUp.java
@@ -142,6 +142,7 @@ public class RapidCatchUp {
    * @param includeTagGroupC include tag group C
    * @param includeTagGroupD include tag group D
    * @param stringHistorical export string historical logs if {@code true}
+   * @param exportDataInUtc export data in ISO 8601 UTC format if {@code true} (instead of local)
    * @return {@link RapidCatchUpTracker} object
    * @throws Exception for {@link DataPoint} getTimeStampAsDate() errors
    * @throws IOException for errors closing exporter
@@ -152,7 +153,8 @@ public class RapidCatchUp {
       boolean includeTagGroupB,
       boolean includeTagGroupC,
       boolean includeTagGroupD,
-      boolean stringHistorical)
+      boolean stringHistorical,
+      boolean exportDataInUtc)
       throws Exception, IOException {
 
     // The end time is the start + catch up duration
@@ -172,7 +174,8 @@ public class RapidCatchUp {
             includeTagGroupB,
             includeTagGroupC,
             includeTagGroupD,
-            stringHistorical);
+            stringHistorical,
+            exportDataInUtc);
 
     RapidCatchUpTracker histTracker;
     try {

--- a/src/main/java/com/hms_networks/americas/sc/extensions/realtimedata/InstantValuesEbdString.java
+++ b/src/main/java/com/hms_networks/americas/sc/extensions/realtimedata/InstantValuesEbdString.java
@@ -1,0 +1,581 @@
+package com.hms_networks.americas.sc.extensions.realtimedata;
+
+import com.ewon.ewonitf.Exporter;
+import com.hms_networks.americas.sc.extensions.datapoint.DataPoint;
+import com.hms_networks.americas.sc.extensions.datapoint.DataPointBoolean;
+import com.hms_networks.americas.sc.extensions.datapoint.DataPointNumber;
+import com.hms_networks.americas.sc.extensions.datapoint.DataPointString;
+import com.hms_networks.americas.sc.extensions.datapoint.DataQuality;
+import com.hms_networks.americas.sc.extensions.historicaldata.HistoricalDataManager;
+import com.hms_networks.americas.sc.extensions.string.StringUtils;
+import com.hms_networks.americas.sc.extensions.system.time.SCTimeUnit;
+import com.hms_networks.americas.sc.extensions.system.time.SCTimeUtils;
+import com.hms_networks.americas.sc.extensions.taginfo.TagInfo;
+import com.hms_networks.americas.sc.extensions.taginfo.TagInfoManager;
+import com.hms_networks.americas.sc.extensions.taginfo.TagType;
+import com.hms_networks.americas.sc.extensions.util.StreamUtils;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Class for working with the Ewon EBD instant values query using the string data output format.
+ * This class is used to parse the EBD data and create data points for each tag value. The string
+ * data output format for the instant values EBD includes tag data for all numeric and string tags.
+ *
+ * <p>It is important to note that the Ewon instant values EBD query does not return full tag
+ * configurations. The {@link TagInfoManager} is used to get tag information for each tag ID, and
+ * must be populated with tag information before using this class.
+ *
+ * <p>Format of the EBD data:
+ *
+ * <ul>
+ *   <li>The values of strings are surrounded by double quotes (“).
+ *   <li>Special characters (quote, double-quote, non-printable) are escaped with a ‘\’.
+ *   <li>Expected Header:
+ *       <ul>
+ *         <li>TagId
+ *         <li>TagName
+ *         <li>Value
+ *         <li>AlStatus
+ *         <li>AlType
+ *         <li>Quality
+ *       </ul>
+ *   <li>Followed by rows/lines for each data entry
+ * </ul>
+ *
+ * <p>Example:
+ *
+ * <pre>
+ * "TagId";"TagName";"Value";"AlStatus";"AlType";"Quality"
+ * 1;"Float_0";5;0;0;65472
+ * 2;"Float_1";6;0;0;65472
+ * 3;"Float_2";7;0;0;65472
+ * 2003;"Str_100";"ABCDEF\"GH\'IJKLMNOPQRSTUVWXYZ";0;0;65472
+ * 2004;"Str_101";"ABCDEFGHIJKLMNOPQRSTUVWXYZ";0;0;65472
+ * 2005;"Str_102";"AT char @";0;0;65472
+ * </pre>
+ *
+ * @author HMS Networks; Americas
+ * @version 1.0.0
+ * @since 1.15.15
+ */
+public class InstantValuesEbdString {
+
+  /**
+   * The EBD instant values string used to execute the EBD call.
+   *
+   * @since 1.0.0
+   */
+  private static final String EBD_INSTANT_VALUES_STRING = "$dtIV $ftT";
+
+  /**
+   * The index of the tag ID in the parsed EBD data.
+   *
+   * @since 1.0.0
+   */
+  private static final int TAG_ID_INDEX = 0;
+
+  /**
+   * The index of the tag name in the parsed EBD data.
+   *
+   * @since 1.0.0
+   */
+  private static final int TAG_NAME_INDEX = 1;
+
+  /**
+   * The index of the value in the parsed EBD data.
+   *
+   * @since 1.0.0
+   */
+  private static final int VALUE_INDEX = 2;
+
+  /**
+   * The index of the quality in the parsed EBD data.
+   *
+   * @since 1.0.0
+   */
+  private static final int QUALITY_INDEX = 5;
+
+  /**
+   * The delimiter character used to separate values in the EBD data.
+   *
+   * @since 1.0.0
+   */
+  private static final char DELIMITER = ';';
+
+  /**
+   * The delimiter character used to separate lines in the EBD data.
+   *
+   * @since 1.0.0
+   */
+  private static final String NEW_LINE_DELIMITER = "\n";
+
+  /**
+   * The encoding used to read the EBD data.
+   *
+   * @since 1.0.0
+   */
+  private static final String EBD_ENCODING = "UTF-8";
+
+  /**
+   * The timestamp of the EBD data.
+   *
+   * @since 1.0.0
+   */
+  private final String iso8601Timestamp;
+
+  /**
+   * Map to store the data points from the EBD data. The key is the tag name and the value is the
+   * data point.
+   *
+   * <p>Parameterized type: Map&lt;String, DataPoint&gt;
+   *
+   * @since 1.0.0
+   */
+  private final Map dataPoints;
+
+  /**
+   * Constructor for the InstantValuesEbdString class. This constructor parses the EBD data and
+   * creates data points for each tag.
+   *
+   * @param date {@link Date} object of the EBD data
+   * @param ebdData the EBD data to parse
+   * @throws Exception when unable to get UTC export value
+   * @throws IllegalStateException when the {@link TagInfoManager} has not been initialized with
+   *     {@link TagInfoManager#refreshTagList()}
+   * @throws IllegalArgumentException if one of the following occurs:
+   *     <ul>
+   *       <li>a tag type cannot be decoded from its tag info and value
+   *       <li>the number of values on a line does not match the number of headings
+   *       <li>a value cannot be parsed as a string, integer, float, long, double, or boolean
+   *     </ul>
+   *
+   * @throws Exception if unable to get UTC export value
+   * @since 1.0.0
+   */
+  public InstantValuesEbdString(Date date, String ebdData)
+      throws Exception, IllegalArgumentException {
+    // Store timestamp
+    this.iso8601Timestamp = SCTimeUtils.getIso8601FormattedTimestampForDate(date);
+    String epochSec = Long.toString(date.getTime() / SCTimeUnit.SECONDS.toMillis(1));
+
+    // Parse the EBD data
+    Object[][] parsedData = parse(ebdData);
+    dataPoints = buildDataPoints(iso8601Timestamp, epochSec, parsedData);
+  }
+
+  /**
+   * Method to execute an EBD call and parse the data into data points for each tag.
+   *
+   * @return an {@link InstantValuesEbdString} object containing the parsed data points
+   * @throws IllegalStateException when the {@link TagInfoManager} has not been initialized with
+   *     {@link TagInfoManager#refreshTagList()}
+   * @throws IllegalArgumentException if one of the following occurs:
+   *     <ul>
+   *       <li>a tag type cannot be decoded from its tag info and value
+   *       <li>the number of values on a line does not match the number of headings
+   *       <li>a value cannot be parsed as a string, integer, float, long, double, or boolean
+   *     </ul>
+   *
+   * @throws Exception if an error occurs while executing the EBD call
+   * @since 1.0.0
+   */
+  public static InstantValuesEbdString doEbd() throws Exception {
+    return doEbd(new Date());
+  }
+
+  /**
+   * Method to execute an EBD call and parse the data into data points for each tag.
+   *
+   * @param date {@link Date} object to associate with the EBD data
+   * @return an {@link InstantValuesEbdString} object containing the parsed data points
+   * @throws IllegalStateException when the {@link TagInfoManager} has not been initialized with
+   *     {@link TagInfoManager#refreshTagList()}
+   * @throws IllegalArgumentException if one of the following occurs:
+   *     <ul>
+   *       <li>a tag type cannot be decoded from its tag info and value
+   *       <li>the number of values on a line does not match the number of headings
+   *       <li>a value cannot be parsed as a string, integer, float, long, double, or boolean
+   *     </ul>
+   *
+   * @throws Exception if an error occurs while executing the EBD call
+   * @since 1.0.0
+   */
+  public static InstantValuesEbdString doEbd(Date date) throws Exception {
+    // Store timestamp and execute EBD call
+    Exporter ebdInstantValuesExporter =
+        HistoricalDataManager.executeEbdCall(EBD_INSTANT_VALUES_STRING);
+
+    // Pull in bytes from Exporter (input stream)
+    String ebdData = StreamUtils.getStringFromInputStream(ebdInstantValuesExporter, EBD_ENCODING);
+    return new InstantValuesEbdString(date, ebdData);
+  }
+
+  /**
+   * Method to build data points from the parsed data.
+   *
+   * @param iso8601Timestamp the timestamp of the EBD data in ISO 8601 format
+   * @param epochSecondsTimestamp the timestamp of the EBD data in epoch seconds
+   * @param parsedData the parsed data
+   * @return a map of data points (Parameterized type: Map&lt;String, DataPoint&gt;)
+   * @throws IllegalArgumentException if a tag type cannot be decoded from its tag info and value
+   * @throws IllegalStateException when the {@link TagInfoManager} has not been initialized with
+   *     {@link TagInfoManager#refreshTagList()}
+   * @since 1.0.0
+   */
+  private static Map buildDataPoints(
+      String iso8601Timestamp, String epochSecondsTimestamp, Object[][] parsedData) {
+    // Create a map to store the data points
+    Map dataPoints = new HashMap(); // Map<String, DataPoint>
+
+    // Loop through each row of the parsed data (except headings)
+    for (int i = 1; i < parsedData.length; i++) {
+      // Get the values for the row
+      Object[] values = parsedData[i];
+
+      // Extract the values from the row
+      int tagId = ((Integer) values[TAG_ID_INDEX]).intValue();
+      String tagName = (String) values[TAG_NAME_INDEX];
+      Object value = values[VALUE_INDEX];
+      int quality = ((Integer) values[QUALITY_INDEX]).intValue();
+
+      // Build required values
+      TagInfo tagInfo = TagInfoManager.getTagInfoFromTagId(tagId);
+      String tagUnit = tagInfo.getUnit();
+      DataQuality dataQuality = DataQuality.fromOpcuaQuality(quality);
+
+      // Create a data point for the tag
+      DataPoint dataPoint;
+
+      // Check if string
+      if (tagInfo.getType() == TagType.STRING) {
+        String valueString = value instanceof String ? (String) value : value.toString();
+        dataPoint =
+            new DataPointString(
+                tagName,
+                tagId,
+                tagUnit,
+                valueString,
+                epochSecondsTimestamp,
+                iso8601Timestamp,
+                dataQuality);
+      } else if (tagInfo.getType() == TagType.BOOLEAN && value instanceof Boolean) {
+        boolean valueBoolean = ((Boolean) value).booleanValue();
+        dataPoint =
+            new DataPointBoolean(
+                tagName,
+                tagId,
+                tagUnit,
+                valueBoolean,
+                epochSecondsTimestamp,
+                iso8601Timestamp,
+                dataQuality);
+      } else {
+        Number valueNumber = (Number) value;
+        if (tagInfo.getType() == TagType.BOOLEAN) {
+          boolean valueBoolean = valueNumber.intValue() != 0;
+          dataPoint =
+              new DataPointBoolean(
+                  tagName,
+                  tagId,
+                  tagUnit,
+                  valueBoolean,
+                  epochSecondsTimestamp,
+                  iso8601Timestamp,
+                  dataQuality);
+        } else if (tagInfo.getType() == TagType.INTEGER) {
+          dataPoint =
+              new DataPointNumber(
+                  tagName,
+                  tagId,
+                  tagUnit,
+                  valueNumber,
+                  epochSecondsTimestamp,
+                  iso8601Timestamp,
+                  dataQuality);
+        } else if (tagInfo.getType() == TagType.FLOAT) {
+          dataPoint =
+              new DataPointNumber(
+                  tagName,
+                  tagId,
+                  tagUnit,
+                  valueNumber,
+                  epochSecondsTimestamp,
+                  iso8601Timestamp,
+                  dataQuality);
+        } else if (tagInfo.getType() == TagType.DWORD) {
+          dataPoint =
+              new DataPointNumber(
+                  tagName,
+                  tagId,
+                  tagUnit,
+                  valueNumber,
+                  epochSecondsTimestamp,
+                  iso8601Timestamp,
+                  dataQuality);
+        } else {
+          throw new IllegalArgumentException(
+              "Failed to create data point for tag ["
+                  + tagName
+                  + "]. Value type cannot be decoded from ["
+                  + value
+                  + "]");
+        }
+      }
+
+      // Add the data point to the map
+      dataPoints.put(tagName, dataPoint);
+    }
+
+    return dataPoints;
+  }
+
+  /**
+   * Method to parse the EBD data into a 2D array of objects.
+   *
+   * @param ebdData the EBD data to parse
+   * @return a 2D array of objects
+   * @throws IllegalArgumentException if the number of values on a line does not match the number of
+   *     headings, or if a value cannot be parsed as a string, integer, float, long, double, or
+   *     boolean
+   * @since 1.0.0
+   */
+  public Object[][] parse(String ebdData) {
+    // Split the EBD data into lines
+    List lines = StringUtils.split(ebdData, NEW_LINE_DELIMITER);
+
+    // Read the header line
+    final int headerLineIndex = 0;
+    String header = (String) lines.get(headerLineIndex);
+    Object[] headings = parseLine(header);
+
+    // Get line count (not including last line if empty)
+    int lastLineIndex = lines.size() - 1;
+    String lastLine = (String) lines.get(lastLineIndex);
+    int lineCount = lastLine.trim().length() > 0 ? lines.size() : lines.size() - 1;
+
+    // Create a 2D array to store the parsed data
+    Object[][] parsedData = new Object[lineCount][headings.length];
+
+    // Loop through each line of the EBD data
+    for (int i = 0; i < lineCount; i++) {
+      // Split the line into individual values
+      String line = (String) lines.get(i);
+      if (line.trim().length() > 0) {
+        Object[] values = parseLine(line);
+
+        // Check if the number of values is equal to the number of headings
+        if (values.length != headings.length) {
+          int lineNumber = i + 1;
+          throw new IllegalArgumentException(
+              "Number of values on line " + lineNumber + " does not match number of headings");
+        }
+
+        // Store the values in the parsed data array
+        parsedData[i] = values;
+      }
+    }
+
+    return parsedData;
+  }
+
+  /**
+   * Get the delimiter indices for the specified line. This method will return an array of integers
+   * representing the indices of the delimiter character in the specified line. It will not include
+   * delimiters that are enclosed within a quoted string, or escaped with a backslash.
+   *
+   * @param line line to get delimiter indices for
+   * @return array of delimiter indices
+   * @since 1.0.0
+   */
+  public int[] getDelimiterIndicesForLine(String line) {
+    List delimiterIndices = new ArrayList(); // List<Integer>
+    boolean inQuotedString = false;
+    boolean escaped = false;
+
+    // Loop through each character in the line
+    for (int i = 0; i < line.length(); i++) {
+      char c = line.charAt(i);
+
+      // Check if the character is a delimiter
+      if (c == DELIMITER && !inQuotedString && !escaped) {
+        delimiterIndices.add(new Integer(i));
+      }
+
+      // Check if the character is a quote
+      if (c == '"') {
+        inQuotedString = !inQuotedString;
+      }
+
+      // Check if the character is an escape character
+      if (c == '\\') {
+        escaped = !escaped;
+      } else {
+        escaped = false;
+      }
+    }
+
+    // Return the list of delimiter indices converted to an array (List<Integer> -> int[])
+    int[] delimiterIndicesArray = new int[delimiterIndices.size()];
+    for (int i = 0; i < delimiterIndices.size(); i++) {
+      delimiterIndicesArray[i] = ((Integer) delimiterIndices.get(i)).intValue();
+    }
+    return delimiterIndicesArray;
+  }
+
+  /**
+   * Parse the specified line into an array of objects. This method will split the line into
+   * individual values using the delimiter character, and return an array of objects representing
+   * the values.
+   *
+   * @param line line to parse
+   * @return array of objects representing the values
+   * @throws IllegalArgumentException if a value cannot be parsed as a string, integer, float, long,
+   *     double, or boolean
+   * @since 1.0.0
+   */
+  public Object[] parseLine(String line) {
+    // Get the delimiter indices for the line
+    int[] delimiterIndices = getDelimiterIndicesForLine(line);
+
+    // Split the line into individual values
+    return parseLine(line, delimiterIndices);
+  }
+
+  /**
+   * Parse the specified line into an array of objects. This method will split the line into
+   * individual values using the delimiter character, and return an array of objects representing
+   * the values.
+   *
+   * @param line line to parse
+   * @param delimiterIndices array of delimiter indices
+   * @return array of objects representing the values
+   * @throws IllegalArgumentException if a value cannot be parsed as a string, integer, float, long,
+   *     double, or boolean
+   * @since 1.0.0
+   */
+  public Object[] parseLine(String line, int[] delimiterIndices) {
+    // Create an array to store the parsed values
+    Object[] values = new Object[delimiterIndices.length + 1];
+
+    // Loop through each delimiter index
+    for (int i = 0; i < delimiterIndices.length; i++) {
+      // Get the start and end indices for the value
+      int start = i == 0 ? 0 : delimiterIndices[i - 1] + 1;
+      int end = delimiterIndices[i];
+
+      // Extract the value from the line and sanitize
+      String value = line.substring(start, end);
+      values[i] = getValueObject(value.trim());
+    }
+
+    // Extract the final value from the line
+    values[delimiterIndices.length] =
+        getValueObject(line.substring(delimiterIndices[delimiterIndices.length - 1] + 1).trim());
+
+    return values;
+  }
+
+  /**
+   * Get the object representation of the specified value. This method will attempt to parse the
+   * value as an integer, float, long, or boolean, and default to a string if parsing fails.
+   * Additionally, this method will unescape special characters in the value.
+   *
+   * @param value value to parse
+   * @return object representation of the value
+   * @throws IllegalArgumentException if the value cannot be parsed as a string, integer, float,
+   *     long, double, or boolean
+   * @since 1.0.0
+   */
+  public Object getValueObject(String value) {
+    Object result;
+
+    // Check if the value is a string (enclosed in quotes)
+    if (value.startsWith("\"") && value.endsWith("\"")) {
+      // Remove the quotes
+      value = value.substring(1, value.length() - 1);
+
+      // Unescape special characters
+      value = StringUtils.replace(value, "\\\"", "\"");
+      value = StringUtils.replace(value, "\\'", "'");
+      value = StringUtils.replace(value, "\\n", "\n");
+      value = StringUtils.replace(value, "\\r", "\r");
+      value = StringUtils.replace(value, "\\t", "\t");
+
+      result = value;
+    } else {
+      // Check if the value is an integer
+      try {
+        int rawInt = Integer.parseInt(value);
+        result = new Integer(rawInt);
+      } catch (NumberFormatException e) {
+        // Check if the value is a float
+        try {
+          float rawFloat = Float.parseFloat(value);
+          result = new Float(rawFloat);
+        } catch (NumberFormatException e1) {
+          // Check if the value is a long
+          try {
+            long rawLong = Long.parseLong(value);
+            result = new Long(rawLong);
+          } catch (NumberFormatException e2) {
+            // Check if the value is a double
+            try {
+              double rawDouble = Double.parseDouble(value);
+              result = new Double(rawDouble);
+            } catch (NumberFormatException e3) {
+              // Check if the value is a boolean
+              if (value.equalsIgnoreCase("true")) {
+                result = Boolean.TRUE;
+              } else if (value.equalsIgnoreCase("false")) {
+                result = Boolean.FALSE;
+              } else {
+                throw new IllegalArgumentException(
+                    "Failed to parse value ["
+                        + value
+                        + "] as a String, Integer, Float, Double, Long, or Boolean!");
+              }
+            }
+          }
+        }
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Get the data points from the EBD data.
+   *
+   * @return a map of data points (Parameterized type: Map&lt;String, DataPoint&gt;)
+   * @since 1.0.0
+   */
+  public Map getDataPoints() {
+    return dataPoints;
+  }
+
+  /**
+   * Get the timestamp of the EBD data.
+   *
+   * @return the timestamp of the EBD data
+   * @since 1.0.0
+   */
+  public String getTimestamp() {
+    return iso8601Timestamp;
+  }
+
+  /**
+   * Get the data point for the specified tag name.
+   *
+   * <p>NOTE: This method will return null if the tag name is not found.
+   *
+   * @param tagName the tag name to get the data point for
+   * @return the data point for the specified tag name
+   */
+  public DataPoint getDataPoint(String tagName) {
+    return (DataPoint) getDataPoints().get(tagName);
+  }
+}

--- a/src/main/java/com/hms_networks/americas/sc/extensions/realtimedata/RealTimeTagDataPointManager.java
+++ b/src/main/java/com/hms_networks/americas/sc/extensions/realtimedata/RealTimeTagDataPointManager.java
@@ -7,9 +7,12 @@ import com.hms_networks.americas.sc.extensions.datapoint.DataPointDword;
 import com.hms_networks.americas.sc.extensions.datapoint.DataPointFloat;
 import com.hms_networks.americas.sc.extensions.datapoint.DataPointString;
 import com.hms_networks.americas.sc.extensions.logging.Logger;
+import com.hms_networks.americas.sc.extensions.system.time.SCTimeUnit;
+import com.hms_networks.americas.sc.extensions.system.time.SCTimeUtils;
 import com.hms_networks.americas.sc.extensions.taginfo.TagInfo;
 import com.hms_networks.americas.sc.extensions.taginfo.TagType;
 import java.util.ArrayList;
+import java.util.Date;
 
 /**
  * This class will hold a list of data points for each tag. One instance of the class is made per
@@ -103,26 +106,35 @@ public class RealTimeTagDataPointManager {
     TagType tagType = tag.getType();
     String tagUnit = tag.getUnit();
     int tagID = tag.getId();
-    final int millisecondsInSeconds = 1000;
-    String timeStampSeconds = String.valueOf(System.currentTimeMillis() / millisecondsInSeconds);
+    String timeStampSeconds =
+        String.valueOf(System.currentTimeMillis() / SCTimeUnit.SECONDS.toMillis(1));
+    String timestampIso8601 = "";
+    try {
+      timestampIso8601 = SCTimeUtils.getIso8601FormattedTimestampForDate(new Date());
+    } catch (Exception e) {
+      Logger.LOG_CRITICAL(
+          "Unable to populate ISO 8601 timestamp for tags due to unexpected Exception.", e);
+    }
     DataPoint data = null;
 
     if (tagControl != null) {
       if (tagType == TagType.FLOAT) {
         float val = (float) tagControl.getTagValueAsDouble();
-        data = new DataPointFloat(tagName, tagID, tagUnit, val, timeStampSeconds);
+        data = new DataPointFloat(tagName, tagID, tagUnit, val, timeStampSeconds, timestampIso8601);
       } else if (tagType == TagType.INTEGER) {
         int val = tagControl.getTagValueAsInt();
-        data = new DataPointFloat(tagName, tagID, tagUnit, val, timeStampSeconds);
+        data = new DataPointFloat(tagName, tagID, tagUnit, val, timeStampSeconds, timestampIso8601);
       } else if (tagType == TagType.STRING) {
         String val = tagControl.getTagValueAsString();
-        data = new DataPointString(tagName, tagID, tagUnit, val, timeStampSeconds);
+        data =
+            new DataPointString(tagName, tagID, tagUnit, val, timeStampSeconds, timestampIso8601);
       } else if (tagType == TagType.BOOLEAN) {
         boolean val = (tagControl.getTagValueAsLong() != 0);
-        data = new DataPointBoolean(tagName, tagID, tagUnit, val, timeStampSeconds);
+        data =
+            new DataPointBoolean(tagName, tagID, tagUnit, val, timeStampSeconds, timestampIso8601);
       } else if (tagType == TagType.DWORD) {
         long val = tagControl.getTagValueAsLong();
-        data = new DataPointDword(tagName, tagID, tagUnit, val, timeStampSeconds);
+        data = new DataPointDword(tagName, tagID, tagUnit, val, timeStampSeconds, timestampIso8601);
       }
     } else {
       Logger.LOG_WARN(


### PR DESCRIPTION
This PR is a pre-release which will be followed up by an additional PR.
Changes:  
- support for tag instant value EBD calls 
- DataPoint classes now support ISO 8601 timestamp 
- Datapoint epoch second timestamps are depreciated, but still included for compatibility 
- Historical Data EBD calls are aware of store data in UTC setting and ISO 8601 timestamps will reflect that setting

Because epoch seconds timestamps support remains, but is deprecated, there is no major revision change planed. 