### PR TITLE
Release/1.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <!-- PROJECT NAME -->
   <name>Ewon Flexy Extensions Library</name>
   <!-- PROJECT VERSION -->
-  <version>1.15.14</version>
+  <version>1.16.0</version>
   <!-- PROJECT GROUP ID (PARENT PACKAGE) -->
   <groupId>com.hms_networks.americas.sc</groupId>
   <!-- PROJECT ARTIFACT ID (ROOT PACKAGE NAME) -->

--- a/src/main/java/com/hms_networks/americas/sc/extensions/historicaldata/HistoricalDataEbdRequest.java
+++ b/src/main/java/com/hms_networks/americas/sc/extensions/historicaldata/HistoricalDataEbdRequest.java
@@ -1,0 +1,243 @@
+package com.hms_networks.americas.sc.extensions.historicaldata;
+
+import com.hms_networks.americas.sc.extensions.system.time.SCTimeUnit;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+/**
+ * Utility methods for building EBD requests for historical data according to Export Block
+ * Descriptor REFERENCE GUIDE RG-0009-00-EN, Publication date 30/08/2023
+ *
+ * @author HMS Americas FAE team
+ * @version 1.0
+ * @since 1.16.0
+ */
+public class HistoricalDataEbdRequest {
+  /** EBD syntax for group filter */
+  private static final String EBD_FIELD_GROUP_FILTER = "$fl";
+
+  /** EBD syntax for data type */
+  private static final String EBD_FIELD_DATA_TYPE = "$dt";
+
+  /** EBD syntax for data type historical log */
+  private static final String EBD_FIELD_DATA_TYPE_HISTORICAL_LOG = "HL";
+
+  /** EBD syntax for data type historical string */
+  private static final String EBD_FIELD_DATA_TYPE_HISTORICAL_STRING = "HS";
+
+  /** EBD syntax for start time */
+  private static final String EBD_FIELD_START_TIME = "$st";
+
+  /** EBD syntax for start time */
+  private static final String EBD_FIELD_END_TIME = "$et";
+
+  /** EBD syntax for respond format text */
+  private static final String EBD_FIELD_FORMAT_AS_TEXT = "$ftT";
+
+  /** EBD syntax for timestamp type */
+  private static final String EBD_FIELD_TIMESTAMP = "$ts";
+
+  /** EBD syntax for Flexy should keep last point in memory for subsequent historical data reads */
+  private static final String EBD_FIELD_UPDATE_TIME = "$ut";
+
+  /**
+   * Get EBD request string for timestamp type.
+   *
+   * @param exportDataInUtc export data with time string as ISO 8601 UTC format if {@code true}
+   *     (instead of local)
+   * @return formatted time string for EBD calls
+   */
+  private static String getEbdTimestampType(boolean exportDataInUtc) {
+    // For details, see RG-0009-00-EN, Publication date 30/08/2023
+    final String EBD_TIME_FORMAT_LOCAL = "L";
+    final String EBD_TIME_FORMAT_UTC = "U";
+    // Get EBD timestamp type
+    String ebdTimestampType;
+    if (exportDataInUtc) {
+      // Results in UTC time format: YYYY-MM-DDTHH:MM:SSZ -Example: 2018-09-19T10:48:12Z
+      ebdTimestampType = EBD_TIME_FORMAT_UTC;
+    } else {
+      // Results in Local time format: YYYY-MM-DDTHH:MM:SS±000 -Example: 2018-09-19T12:48:12+0200
+      ebdTimestampType = EBD_TIME_FORMAT_LOCAL;
+    }
+    return EBD_FIELD_TIMESTAMP + ebdTimestampType;
+  }
+
+  /**
+   * Get EBD request string for group filter.
+   *
+   * @param includeTagGroupA include tag group A
+   * @param includeTagGroupB include tag group B
+   * @param includeTagGroupC include tag group C
+   * @param includeTagGroupD include tag group D
+   * @throws IllegalArgumentException if no tag groups are included
+   * @return EBD request string for tag group filter, can be empty if no tag groups are included
+   */
+  private static String getEbdStringGroupFilter(
+      boolean includeTagGroupA,
+      boolean includeTagGroupB,
+      boolean includeTagGroupC,
+      boolean includeTagGroupD)
+      throws IllegalArgumentException {
+    // Check for valid group selection
+    if (!includeTagGroupA && !includeTagGroupB && !includeTagGroupC && !includeTagGroupD) {
+      throw new IllegalArgumentException(
+          "Cannot generate historical logs with no tag groups selected.");
+    }
+
+    // Build string of tag groups for filter type
+    String tagGroupFilterStr = "";
+    if (includeTagGroupA) {
+      tagGroupFilterStr += "A";
+    }
+    if (includeTagGroupB) {
+      tagGroupFilterStr += "B";
+    }
+    if (includeTagGroupC) {
+      tagGroupFilterStr += "C";
+    }
+    if (includeTagGroupD) {
+      tagGroupFilterStr += "D";
+    }
+
+    return EBD_FIELD_GROUP_FILTER + tagGroupFilterStr;
+  }
+
+  /**
+   * Get EBD string for reading historical tags that are strings. String tags are read from a
+   * different source than non-string tags.
+   *
+   * @return EBD sub string
+   */
+  public static String getEbdStringHistoricalString() {
+    return EBD_FIELD_DATA_TYPE + EBD_FIELD_DATA_TYPE_HISTORICAL_STRING;
+  }
+
+  /**
+   * Get EBD string for reading historical log data type - this does not include string tags.
+   *
+   * @return EBD sub string
+   */
+  private static String getEbdStringHistoricalLog() {
+    return EBD_FIELD_DATA_TYPE + EBD_FIELD_DATA_TYPE_HISTORICAL_LOG;
+  }
+
+  /**
+   * Convert a <code>long</code> time value to format required for absolute start time and end time
+   * EDB calls. Note that this method will format the time in the local time zone which is what EBD
+   * absolute time calls expect.
+   *
+   * @param time <code>long</code> time value to format
+   * @return formatted time string for absolute EBD calls
+   */
+  private static String convertToEbdAbsoluteTimeFormat(long time) {
+    return new SimpleDateFormat(HistoricalDataConstants.EBD_TIME_FORMAT).format(new Date(time));
+  }
+
+  /**
+   * Convert a <code>long</code> epoch millisecond timestamp to format required for relative EBD
+   * calls. Will round to the nearest second. Use of update time makes the lack of precision a
+   * non-issue.
+   *
+   * @param epochTimeMs <code>long</code> time value - should be epoch time in milliseconds
+   * @return formatted time string for relative EBD calls
+   */
+  private static String convertToEbdRelativeTimeFormat(long epochTimeMs) {
+    // the difference between the current time and the epoch time passed as a parameter both rounded
+    // to the nearest second
+    long diffSeconds =
+        SCTimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis())
+            - SCTimeUnit.MILLISECONDS.toSeconds(epochTimeMs);
+    return "s" + Long.toString(diffSeconds);
+  }
+
+  /**
+   * Prepare an EBD string for reading historical data from a Flexy. This method will build the EBD
+   * request based on the provided parameters.
+   *
+   * @param startTime millisecond epoch timestamp for the start time, should be relative to UTC
+   * @param endTime millisecond epoch timestamp for the end time, should be relative to UTC
+   * @param timeRelative if {@code true}, the start and end times are relative to the current time,
+   *     otherwise they are absolute
+   * @param useLastPoint if {@code true}, the last point in memory will be used as the start time
+   * @param updateLastPoint if {@code true}, the last point in memory will be updated to the end
+   *     time
+   * @param includeTagGroupA if {@code true}, include tag group A in the request
+   * @param includeTagGroupB if {@code true}, include tag group B in the request
+   * @param includeTagGroupC if {@code true}, include tag group C in the request
+   * @param includeTagGroupD if {@code true}, include tag group D in the request
+   * @param stringHistorical if {@code true}, the request will be for string historical data,
+   *     otherwise it will be for historical log data
+   * @param exportDataInUtc if {@code true}, the data will be exported in UTC time, otherwise it
+   *     will be exported in local time
+   * @return EBD request string for historical data
+   */
+  public static String prepareHistoricalFifoReadEbdString(
+      long startTime,
+      long endTime,
+      boolean timeRelative,
+      boolean useLastPoint,
+      boolean updateLastPoint,
+      boolean includeTagGroupA,
+      boolean includeTagGroupB,
+      boolean includeTagGroupC,
+      boolean includeTagGroupD,
+      boolean stringHistorical,
+      boolean exportDataInUtc) {
+
+    String dataType;
+    // Add historical log or historical string data type
+    if (stringHistorical) {
+      dataType = getEbdStringHistoricalString();
+    } else {
+      dataType = getEbdStringHistoricalLog();
+    }
+
+    // Add format as text
+    String formatType = (EBD_FIELD_FORMAT_AS_TEXT);
+
+    // Add timestamp type
+    String timestampType = getEbdTimestampType(exportDataInUtc);
+
+    // Add start time
+    String startTimeStr;
+    if (useLastPoint) {
+      startTimeStr = EBD_FIELD_START_TIME + "L";
+    } else {
+      if (timeRelative) {
+        startTimeStr = EBD_FIELD_START_TIME + "_" + convertToEbdRelativeTimeFormat(startTime);
+      } else {
+        startTimeStr = EBD_FIELD_START_TIME + convertToEbdAbsoluteTimeFormat(startTime);
+      }
+    }
+
+    // Add end time
+    String endTimeStr;
+    if (timeRelative) {
+      endTimeStr = EBD_FIELD_END_TIME + "_" + convertToEbdRelativeTimeFormat(endTime);
+    } else {
+      endTimeStr = EBD_FIELD_END_TIME + convertToEbdAbsoluteTimeFormat(endTime);
+    }
+
+    // Add group filter
+    String groupFilter =
+        getEbdStringGroupFilter(
+            includeTagGroupA, includeTagGroupB, includeTagGroupC, includeTagGroupD);
+
+    // Add update time
+    String updateTime;
+    if (updateLastPoint) {
+      updateTime = EBD_FIELD_UPDATE_TIME;
+    } else {
+      updateTime = "";
+    }
+
+    return dataType
+        + formatType
+        + timestampType
+        + startTimeStr
+        + endTimeStr
+        + groupFilter
+        + updateTime;
+  }
+}

--- a/src/main/java/com/hms_networks/americas/sc/extensions/historicaldata/HistoricalDataManager.java
+++ b/src/main/java/com/hms_networks/americas/sc/extensions/historicaldata/HistoricalDataManager.java
@@ -29,7 +29,7 @@ import java.util.Map;
  *
  * @author HMS Networks, MU Americas Solution Center
  * @since 1.0.0
- * @version 3.0.0
+ * @version 3.1.0
  */
 public class HistoricalDataManager {
 
@@ -59,8 +59,7 @@ public class HistoricalDataManager {
    * @throws JSONException if unable to parse int to string enumeration file
    * @throws EbdTimeoutException for EBD timeout
    * @since 1.0.0
-   * @deprecated Use {@link #readHistoricalFifo(String, String, boolean, boolean, boolean, boolean,
-   *     boolean, boolean)} instead.
+   * @deprecated Use {@link #readHistoricalFifo(String requestEbd)} instead.
    */
   public static ArrayList readHistoricalFifo(
       String startTime,
@@ -103,6 +102,7 @@ public class HistoricalDataManager {
    * @throws JSONException if unable to parse int to string enumeration file
    * @throws EbdTimeoutException for EBD timeout
    * @since 3.0.0
+   * @deprecated Use {@link #readHistoricalFifo(String requestEbd)} instead.
    */
   public static ArrayList readHistoricalFifo(
       String startTime,
@@ -133,6 +133,29 @@ public class HistoricalDataManager {
   }
 
   /**
+   * Reads historical log between <code>startTime</code> and <code>endTime</code>. Returns a list of
+   * data points.
+   *
+   * <p>In version 3.0.0 and later, this method returns data points with an ISO 8601 formatted
+   * timestamp. Previous versions used a timestamp integer with the number of seconds since epoch,
+   * thus callers of this method must adapt as necessary.
+   *
+   * @param requestEbd historical data request EBD string
+   * @return data points from response
+   * @throws IOException if export block descriptor fails
+   * @throws JSONException if unable to parse int to string enumeration file
+   * @throws EbdTimeoutException for EBD timeout
+   * @since 3.0.0
+   */
+  public static ArrayList readHistoricalFifo(String requestEbd)
+      throws IOException, JSONException, EbdTimeoutException {
+
+    // Execute EBD call and parse results
+    final Exporter exporter = executeEbdCall(requestEbd);
+    return parseEBDHistoricalLogExportResponse(exporter);
+  }
+
+  /**
    * Reads historical log between <code>startTime</code> and <code>endTime</code>. Returns a map of
    * rounded timestamps to lists of data points. <br>
    * (Parameterized map type: Map&lt;Date, List&lt;DataPoint&gt;&gt;)
@@ -155,9 +178,9 @@ public class HistoricalDataManager {
    * @throws EbdTimeoutException for EBD timeout
    * @throws IllegalArgumentException if time unit is null, unknown, or not supported
    * @throws Exception if unable to parse data point timestamp to date
+   * @return map object of data points
    * @since 1.0.0
-   * @deprecated Use {@link #readHistoricalFifo(String, String, boolean, boolean, boolean, boolean,
-   *     boolean, boolean, SCTimeSpan)} instead.
+   * @deprecated use {@link #readHistoricalFifo(String requestEbd, SCTimeSpan timeSpan) } instead.
    */
   public static Map readHistoricalFifo(
       String startTime,
@@ -206,6 +229,7 @@ public class HistoricalDataManager {
    * @throws IllegalArgumentException if time unit is null, unknown, or not supported
    * @throws Exception if unable to parse data point timestamp to date
    * @since 3.0.0
+   * @deprecated use {@link #readHistoricalFifo(String requestEbd, SCTimeSpan timeSpan)} instead.
    */
   public static Map readHistoricalFifo(
       String startTime,
@@ -233,6 +257,32 @@ public class HistoricalDataManager {
 
     // Execute EBD call and parse results
     final Exporter exporter = executeEbdCall(ebdStr);
+    return parseEBDHistoricalLogExportResponse(exporter, timeSpan);
+  }
+
+  /**
+   * Reads historical log between <code>startTime</code> and <code>endTime</code>. Returns a map of
+   * rounded timestamps to lists of data points. <br>
+   * (Parameterized map type: Map&lt;Date, List&lt;DataPoint&gt;&gt;)
+   *
+   * <p>In version 3.0.0 and later, this method returns data points with an ISO 8601 formatted
+   * timestamp. Previous versions used a timestamp integer with the number of seconds since epoch,
+   * thus callers of this method must adapt as necessary.
+   *
+   * @param requestEbd historical data request EBD string
+   * @param timeSpan time span to round data point time stamps to
+   * @return data points from response
+   * @throws IOException if export block descriptor fails
+   * @throws JSONException if unable to parse int to string enumeration file
+   * @throws EbdTimeoutException for EBD timeout
+   * @throws IllegalArgumentException if time unit is null, unknown, or not supported
+   * @throws Exception if unable to parse data point timestamp to date
+   * @since 3.0.0
+   */
+  public static Map readHistoricalFifo(String requestEbd, SCTimeSpan timeSpan) throws Exception {
+
+    // Execute EBD call and parse results
+    final Exporter exporter = executeEbdCall(requestEbd);
     return parseEBDHistoricalLogExportResponse(exporter, timeSpan);
   }
 
@@ -282,6 +332,7 @@ public class HistoricalDataManager {
    * @param exportDataInUtc export data in ISO 8601 UTC format if {@code true} (instead of local)
    * @return EBD string
    * @since 1.0.0
+   * @deprecated - Use method from {@link HistoricalDataEbdRequest}
    */
   static String prepareHistoricalFifoReadEBDString(
       String startTime,

--- a/src/main/java/com/hms_networks/americas/sc/extensions/package.html
+++ b/src/main/java/com/hms_networks/americas/sc/extensions/package.html
@@ -5,7 +5,7 @@ environment by the HMS Networks, MU Americas Solution Center. These
 extension classes include many supplemental features, and the addition
 of new functionality which may not be present in the supported Java version.
 
-@version 1.15.14
+@version 1.16.0
 @author HMS Networks, MU Americas Solution Center
 </BODY>
 </HTML>

--- a/src/main/java/com/hms_networks/americas/sc/extensions/system/time/LocalTimeOffsetCalculator.java
+++ b/src/main/java/com/hms_networks/americas/sc/extensions/system/time/LocalTimeOffsetCalculator.java
@@ -130,4 +130,23 @@ public class LocalTimeOffsetCalculator {
 
     return diffInMilliseconds;
   }
+
+  /**
+   * Converts the local epoch milliseconds timestamp to UTC epoch milliseconds. Flexy EBD historical
+   * data response will return integer timestamps in local time when "Record Data in UTC" is not
+   * enabled, so this method can be used to convert the local time to UTC time. This method should
+   * only be called after {@link #calculateLocalTimeOffsetMilliseconds()}. Please see usage of
+   * CheckUpdateTimeZone() from {@link TimeZoneManager} as the suggested way to do this.
+   *
+   * @param localEpochMillis the local epoch milliseconds timestamp
+   * @return epoch milliseconds timestamp relative to UTC
+   * @throws InterruptedException if interrupted while attempting script expression export block
+   *     descriptor call
+   * @throws ParseException if unable to parse script expression export block descriptor call result
+   *     (local time)
+   */
+  public static long convertLocalEpochMillisToUtc(long localEpochMillis)
+      throws InterruptedException, ParseException {
+    return localEpochMillis + getLocalTimeOffsetMilliseconds();
+  }
 }

--- a/src/main/java/com/hms_networks/americas/sc/extensions/system/time/LocalTimeOffsetCalculator.java
+++ b/src/main/java/com/hms_networks/americas/sc/extensions/system/time/LocalTimeOffsetCalculator.java
@@ -8,6 +8,7 @@ import com.hms_networks.americas.sc.extensions.string.StringUtils;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.TimeZone;
 
 /**
  * Utility class for calculating the offset between the local time zone and UTC.
@@ -117,6 +118,7 @@ public class LocalTimeOffsetCalculator {
 
     // Get local time from contents of local time offset result file
     SimpleDateFormat sdf = new SimpleDateFormat(TimeLibConstants.TIME_OFFSET_DATE_FORMAT);
+    sdf.setTimeZone(TimeZone.getTimeZone(TimeLibConstants.GMT_TIME_ZONE_NAME));
     Date localTimeDateObj = sdf.parse(localTime);
 
     // Calculate difference between UTC time (Ewon system time) and local time (in milliseconds)

--- a/src/main/java/com/hms_networks/americas/sc/extensions/system/time/SCTimeUtils.java
+++ b/src/main/java/com/hms_networks/americas/sc/extensions/system/time/SCTimeUtils.java
@@ -31,9 +31,6 @@ public class SCTimeUtils {
    */
   private static final String SCB_UTC_EXPORT_VALUE_TRUE = "1";
 
-  /** The name of the Java time zone representing GMT/UTC. */
-  private static final String GMT_TIME_ZONE_NAME = "GMT";
-
   /** The designator used for the GMT/UTC time zone, which has no offset. */
   private static final String GMT_TIME_ZONE_DESIGNATOR = "Z";
 
@@ -175,18 +172,19 @@ public class SCTimeUtils {
     TimeZone.setDefault(newTimeZone);
 
     // Build applicable date formats
-    boolean isTimeZoneGmt = newTimeZone.getDisplayName().equals(GMT_TIME_ZONE_NAME);
+    boolean isTimeZoneGmt =
+        newTimeZone.getDisplayName().equals(TimeLibConstants.GMT_TIME_ZONE_NAME);
     localTimeZoneDesignator =
         isTimeZoneGmt
             ? GMT_TIME_ZONE_DESIGNATOR
-            : newTimeZone.getDisplayName().substring(GMT_TIME_ZONE_NAME.length());
+            : newTimeZone.getDisplayName().substring(TimeLibConstants.GMT_TIME_ZONE_NAME.length());
     final String localTimeFormatString =
         SIMPLE_DATE_FORMAT_PATTERN_ISO_8601 + "'" + localTimeZoneDesignator + "'";
     final String utcTimeFormatString =
         SIMPLE_DATE_FORMAT_PATTERN_ISO_8601 + "'" + GMT_TIME_ZONE_DESIGNATOR + "'";
     iso8601LocalTimeFormat = new SimpleDateFormat(localTimeFormatString, Locale.getDefault());
     iso8601UtcTimeFormat = new SimpleDateFormat(utcTimeFormatString, Locale.getDefault());
-    iso8601UtcTimeFormat.setTimeZone(TimeZone.getTimeZone(GMT_TIME_ZONE_NAME));
+    iso8601UtcTimeFormat.setTimeZone(TimeZone.getTimeZone(TimeLibConstants.GMT_TIME_ZONE_NAME));
   }
 
   /**

--- a/src/main/java/com/hms_networks/americas/sc/extensions/system/time/TimeLibConstants.java
+++ b/src/main/java/com/hms_networks/americas/sc/extensions/system/time/TimeLibConstants.java
@@ -17,4 +17,7 @@ public class TimeLibConstants {
    * https://developer.ewon.biz/content/export-block-descriptor.
    */
   public static final String TIME_OFFSET_LOCAL_TIME_EBD = "$dtSE$se\"Time$\"$ftT";
+
+  /** The name of the Java time zone representing GMT/UTC. */
+  public static final String GMT_TIME_ZONE_NAME = "GMT";
 }

--- a/src/main/java/com/hms_networks/americas/sc/extensions/system/time/TimeZoneManager.java
+++ b/src/main/java/com/hms_networks/americas/sc/extensions/system/time/TimeZoneManager.java
@@ -1,0 +1,76 @@
+package com.hms_networks.americas.sc.extensions.system.time;
+
+import java.util.Date;
+
+/**
+ * Class which provides management of the JVM time zone. The Flexy JVM provides only a single
+ * TimeZone object: GMT. This class will check when to measure the local time zone offset and set
+ * the default time zone for the JVM. Having the proper time zone offset allows for proper creation
+ * of Date objects and other time-related operations. The update in necessary to handle daylight
+ * savings time.
+ *
+ * @author HMS Networks, MU Americas Solution Center
+ * @since 1.16.0
+ */
+public class TimeZoneManager {
+
+  /** Tracking time zone update minutes. Initialize to -1 to indicate has not been set. */
+  private static int tzTrackMinutes = -1;
+
+  /** Tracking time zone update hours. Initialized to -1 to indicate has not been set. */
+  private static int tzTrackHour = -1;
+
+  /**
+   * Default interval for time zone update check. This value will provide checks on the 0, 15, 30
+   * and 45 minute of every hour. These offsets are when daylight savings time changes occur.
+   */
+  private static final int DEFAULT_UPDATE_MINS = 15;
+
+  /** Check for timezone updates on this interval. */
+  private static int timeZoneCheckIntervalMins = DEFAULT_UPDATE_MINS;
+
+  /**
+   * Set the time zone check interval in minutes. The interval is used to determine when to check if
+   * the time zone offset should be updated. The default interval is 15 minutes.
+   *
+   * @param intervalMins the interval in minutes
+   */
+  public static void setTimeZoneCheckIntervalMins(int intervalMins) {
+    timeZoneCheckIntervalMins = intervalMins;
+  }
+
+  /**
+   * This method will round down the minute value to a whole interval. For example, if the interval
+   * is 15 minutes, and the minute is 17, the rounded down value will be 15. Rounding down is
+   * necessary for the timing of the time zone update.
+   *
+   * @param minute the minute value to round
+   * @return the rounded down minute value
+   */
+  private static int roundDownMinuteValue(int minute) {
+    return (minute / timeZoneCheckIntervalMins) * timeZoneCheckIntervalMins;
+  }
+
+  /**
+   * Check the if current time should trigger a potential local time zone offset (offset from GMT)
+   * change. The check is based on the current hour and the rounded down minute; when one or both of
+   * these values have changed, an update will be triggered. The update action is to call the
+   * injectJvmLocalTime method. This may change the JVM's default time zone.
+   *
+   * @throws Exception if an error occurs while checking the time zone offset, or injecting the
+   *     local time offset.
+   */
+  public static void checkUpdateTimeZone() throws Exception {
+    Date current = new Date();
+    int hour = current.getHours();
+    int minute = roundDownMinuteValue(current.getMinutes());
+    if (hour == tzTrackHour && minute == tzTrackMinutes) {
+      return;
+    }
+    // Update the tracking values
+    tzTrackHour = hour;
+    tzTrackMinutes = minute;
+    // Inject the local time zone offset
+    SCTimeUtils.injectJvmLocalTime();
+  }
+}

--- a/starting-files/jvmrun
+++ b/starting-files/jvmrun
@@ -1,1 +1,1 @@
--heapsize 25M -classpath /usr/extensions-1.15.14-full.jar -emain com.hms_networks.americas.sc.extensions.ExtensionsMain
+-heapsize 25M -classpath /usr/extensions-1.16.0-full.jar -emain com.hms_networks.americas.sc.extensions.ExtensionsMain

--- a/web-docs/docs/02-CHANGELOG.mdx
+++ b/web-docs/docs/02-CHANGELOG.mdx
@@ -5,6 +5,18 @@ sidebar_label: Change Log
 toc_max_heading_level: 2
 ---
 
+## Version 1.16.0
+### Features
+- Makes use of "Record Data in UTC" setting in Ewon to determine if timestamps are in UTC or local time
+- Historical data points support new method for getting the timestamp as an ISO-8601 formatted string
+- TimeZoneManager class for checking and managing the time zone offset 
+- Historical data EBD requests use relative time instead of absolute time
+- Added method to get all instant values via EBD
+### Bug Fixes
+- Corrected errors in multiple calculations of offset
+- Corrected errors data point timestamps related to timezone change 
+- Added missing JavaDoc comments
+
 ## Version 1.15.14
 ### Features
 - Added overrideTagUnit method to DataPoint class to allow for setting the unit of a data point

--- a/web-docs/docs/_partial/_pom_library.mdx
+++ b/web-docs/docs/_partial/_pom_library.mdx
@@ -7,7 +7,7 @@ import ScDocusaurusConfig from "@site/ScDocusaurusConfig.js";
   <dependency>
     <groupId>com.hms_networks.americas.sc</groupId>
     <artifactId>extensions</artifactId>
-    <version>1.15.14</version>
+    <version>1.16.0</version>
   </dependency>
   ...
 </dependencies>


### PR DESCRIPTION
This PR addresses the issue of time zone handling 
- support maintaining JVM time zone offset from GMT/UTC. This is needed for many java features to work properly. Previous the time zone offset was only calculated once at start. Now it is possible to continuously check and update offset 
- Change EBD historical data calls to use relative format and not absolute. Absolute format utilized local timestamps; there is inherit limitations of this type of system


Additional feature of Instant values EBD call to return instant tag values 

closes #98 
closes #90 
